### PR TITLE
fix(uno): min/max-w using theme breakpoint values

### DIFF
--- a/packages/uno-preset/src/theme.ts
+++ b/packages/uno-preset/src/theme.ts
@@ -1,6 +1,6 @@
 import type { ThemeExtender } from "@unocss/core";
 import type { Theme } from "@unocss/preset-wind3";
-import { next as hvTheme, theme } from "@hitachivantara/uikit-styles";
+import { pentaho as hvTheme, theme } from "@hitachivantara/uikit-styles";
 
 // #region theme conversion utils
 const { light: defaultColors } = hvTheme.colors;
@@ -25,6 +25,8 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
     ...theme.radii,
   },
   breakpoints: Object.fromEntries(hvBreakpoints),
+  maxWidth: Object.fromEntries(hvBreakpoints),
+  minWidth: Object.fromEntries(hvBreakpoints),
   containers: Object.fromEntries(
     hvBreakpoints.map(([k, v]) => [k, `(min-width: ${v})`]),
   ),
@@ -47,10 +49,9 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
 
   // typography
   fontFamily: {
+    ...baseTheme.fontFamily,
     body: hvTheme.fontFamily.body,
     sans: hvTheme.fontFamily.body,
-    serif: hvTheme.fontFamily.body,
-    mono: "monospace",
   },
   lineHeight: { DEFAULT: hvTheme.lineHeights.base, ...hvTheme.lineHeights },
   fontSize: { DEFAULT: hvTheme.fontSizes.base, ...hvTheme.fontSizes },


### PR DESCRIPTION
`max-w-*` and `min-w-*` use theme breakpoint values instead of spacing values