### PR TITLE
feat(core): migrate HvGrid to MUI Grid

### DIFF
--- a/apps/app/src/pages/Components.tsx
+++ b/apps/app/src/pages/Components.tsx
@@ -389,7 +389,7 @@ const Table = () => {
 export const Component = () => {
   return (
     <HvGrid container>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvGlobalActions
           variant="global"
           title="UI Kit Component Library"
@@ -403,24 +403,24 @@ export const Component = () => {
         </HvGlobalActions>
       </HvGrid>
 
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvBreadCrumb
           aria-label="Navigation"
           url="https://pentaho.github.io/uikit-docs/master/components/button"
         />
       </HvGrid>
-      <HvGrid item xs={12} sm={6} lg={4}>
+      <HvGrid size={{ xs: 12, sm: 6, lg: 4 }}>
         <Panel1 />
       </HvGrid>
-      <HvGrid item xs={12} sm={6} lg={4}>
+      <HvGrid size={{ xs: 12, sm: 6, lg: 4 }}>
         <Panel2 />
       </HvGrid>
-      <HvGrid item xs={12} sm={6} lg={4}>
+      <HvGrid size={{ xs: 12, sm: 6, lg: 4 }}>
         <HvTableSection>
           <Table />
         </HvTableSection>
       </HvGrid>
-      <HvGrid item xs={12} sm={6} lg={4}>
+      <HvGrid size={{ xs: 12, sm: 6, lg: 4 }}>
         <Card1 />
       </HvGrid>
     </HvGrid>

--- a/apps/default-app/src/pages/DisplayDefaultAppContext/DisplayDefaultAppContext.tsx
+++ b/apps/default-app/src/pages/DisplayDefaultAppContext/DisplayDefaultAppContext.tsx
@@ -19,7 +19,7 @@ export const DisplayDefaultAppContext = () => {
       />
 
       <HvGrid container>
-        <HvGrid item xs={12} display="flex">
+        <HvGrid display="flex" size={12}>
           <HvTypography variant="label">{text}</HvTypography>
         </HvGrid>
       </HvGrid>

--- a/apps/default-app/src/pages/Navigation/Navigation.tsx
+++ b/apps/default-app/src/pages/Navigation/Navigation.tsx
@@ -35,23 +35,23 @@ const Navigation = () => {
       <HvGlobalActions title="Navigation" className="mb-xs" />
 
       <HvGrid container className="mb-xs">
-        <HvGrid item xs={12} display="flex">
+        <HvGrid display="flex" size={12}>
           <HvTypography variant="label">
             For the correct usage of this page, it is required that simple app
             is available.
           </HvTypography>
         </HvGrid>
-        <HvGrid item xs={12} display="flex">
+        <HvGrid display="flex" size={12}>
           <HvTypography link component={Link} to={internalNavigation}>
             Detail: Internal Navigation (/pages/Details)
           </HvTypography>
         </HvGrid>
-        <HvGrid item xs={12} display="flex">
+        <HvGrid display="flex" size={12}>
           <HvTypography link component={Link} to={scopedNavigation}>
             Light Mode: Scoped bundle navigation (@hv/sample-app/pages/Home)
           </HvTypography>
         </HvGrid>
-        <HvGrid item xs={12} display="flex">
+        <HvGrid display="flex" size={12}>
           <HvTypography link component={Link} to={nonScopedNavigation}>
             Dark Mode: Non scoped bundle navigation (@hv/sample-app/pages/Home)
           </HvTypography>

--- a/apps/default-app/src/pages/Notifications/Notifications.tsx
+++ b/apps/default-app/src/pages/Notifications/Notifications.tsx
@@ -73,7 +73,7 @@ const Notifications = () => {
       <HvGlobalActions title="Notifications" className="mb-xs" />
 
       <HvGrid container className="mb-xs">
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvInput
             type="text"
             label="Notification text"
@@ -87,22 +87,22 @@ const Notifications = () => {
           />
         </HvGrid>
 
-        <HvGrid item xs={12} display="flex" justifyContent="center">
+        <HvGrid display="flex" justifyContent="center" size={12}>
           <HvTypography variant="title3">Snackbars</HvTypography>
         </HvGrid>
 
-        <HvGrid item xs={12} display="flex" justifyContent="space-evenly">
+        <HvGrid display="flex" justifyContent="space-evenly" size={12}>
           {renderTriggerNotificationButton("snackbar", "default")}
           {renderTriggerNotificationButton("snackbar", "success")}
           {renderTriggerNotificationButton("snackbar", "warning")}
           {renderTriggerNotificationButton("snackbar", "error")}
         </HvGrid>
 
-        <HvGrid item xs={12} display="flex" justifyContent="center">
+        <HvGrid display="flex" justifyContent="center" size={12}>
           <HvTypography variant="title3">Banners</HvTypography>
         </HvGrid>
 
-        <HvGrid item xs={12} display="flex" justifyContent="space-evenly">
+        <HvGrid display="flex" justifyContent="space-evenly" size={12}>
           {renderTriggerNotificationButton("banner", "default")}
           {renderTriggerNotificationButton("banner", "success")}
           {renderTriggerNotificationButton("banner", "warning")}

--- a/apps/default-app/src/pages/ServicesDemo/ServicesDemo.tsx
+++ b/apps/default-app/src/pages/ServicesDemo/ServicesDemo.tsx
@@ -103,10 +103,10 @@ const FactoryServiceDemo: FC = () => {
         </HvTypography>
 
         <HvGrid container spacing={2} style={{ marginBottom: "16px" }}>
-          <HvGrid item>
+          <HvGrid>
             <HvButton onClick={handleFormatMessage}>Format Message</HvButton>
           </HvGrid>
-          <HvGrid item>
+          <HvGrid>
             <HvButton onClick={handleGetWelcome}>Get Welcome</HvButton>
           </HvGrid>
         </HvGrid>
@@ -180,7 +180,7 @@ const InstanceBundleServiceDemo: FC = () => {
               if (!action) return null;
 
               return (
-                <HvGrid item key={action.id}>
+                <HvGrid key={action.id}>
                   <HvButton onClick={action.onAction}>
                     {action.label || `Action ${index + 1}`}
                   </HvButton>
@@ -246,19 +246,19 @@ const ServicesDemo: FC = () => {
       </HvTypography>
 
       <HvGrid container spacing={3}>
-        <HvGrid item xs={12} md={6}>
+        <HvGrid size={{ xs: 12, md: 6 }}>
           <InstanceServiceDemo />
         </HvGrid>
 
-        <HvGrid item xs={12} md={6}>
+        <HvGrid size={{ xs: 12, md: 6 }}>
           <FactoryServiceDemo />
         </HvGrid>
 
-        <HvGrid item xs={12} md={6}>
+        <HvGrid size={{ xs: 12, md: 6 }}>
           <InstanceBundleServiceDemo />
         </HvGrid>
 
-        <HvGrid item xs={12} md={6}>
+        <HvGrid size={{ xs: 12, md: 6 }}>
           <ComponentServiceDemo />
         </HvGrid>
       </HvGrid>

--- a/apps/default-app/src/pages/Theming/Theming.tsx
+++ b/apps/default-app/src/pages/Theming/Theming.tsx
@@ -39,11 +39,11 @@ const Theming = () => {
       <HvGlobalActions title="Theming" className="mb-xs" />
 
       <HvGrid container className="mb-xs">
-        <HvGrid item xs={12} display="flex" justifyContent="center">
+        <HvGrid display="flex" justifyContent="center" size={12}>
           <HvTypography variant="title3">Color mode</HvTypography>
         </HvGrid>
 
-        <HvGrid item xs={12} display="flex" justifyContent="space-evenly">
+        <HvGrid display="flex" justifyContent="space-evenly" size={12}>
           {colorModes.map((colorMode) => (
             <Button key={colorMode} colorMode={colorMode} />
           ))}

--- a/apps/docs/src/content/components/dialog.mdx
+++ b/apps/docs/src/content/components/dialog.mdx
@@ -337,13 +337,13 @@ export default function Demo() {
 
 const DialogForm = () => (
   <HvGrid container rowSpacing="xs">
-    <HvGrid item xs={12}>
+    <HvGrid size={12}>
       <HvInput required name="author" label="Author" defaultValue="John Doe" />
     </HvGrid>
-    <HvGrid item xs={12}>
+    <HvGrid size={12}>
       <HvInput required name="title" label="Title" autoFocus />
     </HvGrid>
-    <HvGrid item xs={12}>
+    <HvGrid size={12}>
       <HvTextArea name="content" label="Description" rows={4} />
     </HvGrid>
   </HvGrid>

--- a/apps/docs/src/content/components/grid.mdx
+++ b/apps/docs/src/content/components/grid.mdx
@@ -13,6 +13,12 @@ import { Header } from "../../components/Header";
 
 The example below illustrates a common grid layout where items occupy different number of columns based on the screen size.
 
+Use the `size` prop to define each grid item's responsive span.
+
+> [!NOTE]
+>
+> Legacy props like `item`, `xs`, `sm`, `md`, `lg`, and `xl` are still supported for compatibility, but `size` is the preferred API.
+
 ```tsx live
 export default function Demo() {
   const width = useWidth();
@@ -20,47 +26,47 @@ export default function Demo() {
     <div className="flex flex-col gap-sm">
       <HvTypography variant="label">{`Current width: ${width}`}</HvTypography>
       <HvGrid container>
-        <HvGrid item xs={12} lg={6}>
+        <HvGrid size={{ xs: 12, lg: 6 }}>
           <HvPanel className="content-center h-100px">xs=12 lg=6</HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} lg={6}>
+        <HvGrid size={{ xs: 12, lg: 6 }}>
           <HvPanel className="content-center h-100px">xs=12 lg=6</HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} md={6} lg={4}>
+        <HvGrid size={{ xs: 12, md: 6, lg: 4 }}>
           <HvPanel className="content-center h-100px">xs=12 md=6 lg=4</HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} md={6} lg={4}>
+        <HvGrid size={{ xs: 12, md: 6, lg: 4 }}>
           <HvPanel className="content-center h-100px">xs=12 md=6 lg=4</HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} md={6} lg={4}>
+        <HvGrid size={{ xs: 12, md: 6, lg: 4 }}>
           <HvPanel className="content-center h-100px">xs=12 md=6 lg=4</HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} sm={6} lg={3} xl={2}>
+        <HvGrid size={{ xs: 12, sm: 6, lg: 3, xl: 2 }}>
           <HvPanel className="content-center h-100px">
             xs=12 sm=6 lg=3 xl=2
           </HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>
+        <HvGrid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 2 }}>
           <HvPanel className="content-center h-100px">
             xs=12 sm=6 md=4 lg=3 xl=2
           </HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>
+        <HvGrid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 2 }}>
           <HvPanel className="content-center h-100px">
             xs=12 sm=6 md=4 lg=3 xl=2
           </HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>
+        <HvGrid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 2 }}>
           <HvPanel className="content-center h-100px">
             xs=12 sm=6 md=4 lg=3 xl=2
           </HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>
+        <HvGrid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 2 }}>
           <HvPanel className="content-center h-100px">
             xs=12 sm=6 md=4 lg=3 xl=2
           </HvPanel>
         </HvGrid>
-        <HvGrid item xs={12} sm={6} md={4} lg={3} xl={2}>
+        <HvGrid size={{ xs: 12, sm: 6, md: 4, lg: 3, xl: 2 }}>
           <HvPanel className="content-center h-100px">
             xs=12 sm=6 md=4 lg=3 xl=2
           </HvPanel>
@@ -86,7 +92,7 @@ export default function Demo() {
       <HvTypography variant="label">{`Current width: ${width} (gutter size: ${BREAKPOINT_GUTTERS[width]})`}</HvTypography>
       <HvGrid container>
         {columns.map((value) => (
-          <HvGrid key={value} item xs={1}>
+          <HvGrid key={value} size={1}>
             <HvPanel className="content-center h-100px">
               {value.toString()}
             </HvPanel>
@@ -130,7 +136,7 @@ export default function Demo() {
       <HvTypography variant="label">{`Current width: ${width} (${BREAKPOINT_COLUMNS[width]} columns)`}</HvTypography>
       <HvGrid container columns="auto">
         {columns.map((value) => (
-          <HvGrid key={value} item xs={1}>
+          <HvGrid key={value} size={1}>
             <HvPanel className="content-center h-100px">
               {value.toString()}
             </HvPanel>

--- a/apps/docs/src/content/components/grid.mdx
+++ b/apps/docs/src/content/components/grid.mdx
@@ -17,7 +17,7 @@ Use the `size` prop to define each grid item's responsive span.
 
 > [!NOTE]
 >
-> Legacy props like `item`, `xs`, `sm`, `md`, `lg`, and `xl` are still supported for compatibility, but `size` is the preferred API.
+> Legacy breakpoint props (`xs`, `sm`, `md`, `lg`, `xl`) were removed. Use `size` for all responsive spans.
 
 ```tsx live
 export default function Demo() {

--- a/apps/docs/src/content/docs/layout.mdx
+++ b/apps/docs/src/content/docs/layout.mdx
@@ -54,17 +54,17 @@ This component is ideal when your content should stay within a specific width. U
 
 The [`HvGrid`](/components/grid) component lets you build responsive grid layouts with a customizable number of columns. Grid items automatically adapt to different screen sizes.
 
-By default, the grid uses a 12-column layout. You can customize this using the `columns` prop—set it to a specific number for a fixed column count, or use `auto` to apply responsive behavior based on the default breakpoints.
+By default, the grid uses a 12-column layout. You can customize this using the `columns` prop, set it to a specific number for a fixed column count, or use `auto` to apply responsive behavior based on the default breakpoints.
 Grid items can also span across multiple columns, allowing you to build flexible and adaptive layouts to fit your design needs.
 
 ```tsx live
 <HvGrid columns="auto" container>
-  <HvGrid item xs={4} sm={8} md={12}>
+  <HvGrid size={{ xs: 4, sm: 8, md: 12 }}>
     <HvGlobalActions title="Dashboard" />
   </HvGrid>
   {Array.from({ length: 4 }).map((v, i) => {
     return (
-      <HvGrid item xs={4} sm={4} md={3} lg={3} key={i}>
+      <HvGrid size={{ xs: 4, sm: 4, md: 3, lg: 3 }} key={i}>
         <HvCard
           statusColor={i === 0 ? "warning" : "positive"}
           bgcolor="bgContainer"
@@ -92,7 +92,7 @@ Grid items can also span across multiple columns, allowing you to build flexible
       </HvGrid>
     );
   })}
-  <HvGrid item xs={4} sm={8} md={12}>
+  <HvGrid size={{ xs: 4, sm: 8, md: 12 }}>
     <HvCard bgcolor="bgContainer">
       <HvCardContent>
         <HvVizProvider>

--- a/apps/docs/src/examples/forms/NativeForm.tsx
+++ b/apps/docs/src/examples/forms/NativeForm.tsx
@@ -29,16 +29,16 @@ export default () => (
     }}
   >
     <HvGrid container maxWidth="md" rowSpacing="xs">
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput required name="name" label="Full Name" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput required type="email" name="email" label="Email" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput name="street-address" label="Address" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput
           name="country-name"
           label="Country"
@@ -51,19 +51,19 @@ export default () => (
           }
         />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput name="tel" label="Phone number" endAdornment={<Phone />} />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput type="password" name="password" label="Password" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvDatePicker name="bday" label="Birthday" placeholder="Select date" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvTimePicker name="startTime" label="Start time" />
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvTextArea
           required
           name="description"
@@ -74,14 +74,14 @@ export default () => (
           maxCharQuantity={128}
         />
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvRadioGroup required name="sex" label="Sex" orientation="horizontal">
           <HvRadio value="male" label="Male" />
           <HvRadio value="female" label="Female" />
           <HvRadio value="other" label="Other" />
         </HvRadioGroup>
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvCheckBox
           defaultChecked
           name="subscribe"
@@ -89,7 +89,7 @@ export default () => (
           value="yes"
         />
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvButton type="submit">Submit</HvButton>
       </HvGrid>
     </HvGrid>

--- a/apps/docs/src/examples/forms/ReactForm.tsx
+++ b/apps/docs/src/examples/forms/ReactForm.tsx
@@ -99,7 +99,7 @@ export default () => {
       }}
     >
       <HvGrid container maxWidth="md" rowSpacing="xs">
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvInput
             required
             inputProps={{ required: false }} // disable default browser behavior
@@ -110,7 +110,7 @@ export default () => {
             onChange={(evt, val) => setValue("name", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvInput
             required
             inputProps={{ required: false }} // disable default browser behavior
@@ -122,7 +122,7 @@ export default () => {
             onChange={(evt, val) => setValue("email", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvInput
             name="address"
             label="Address"
@@ -131,7 +131,7 @@ export default () => {
             onChange={(evt, val) => setValue("address", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvInput
             name="country"
             label="Country"
@@ -142,7 +142,7 @@ export default () => {
             endAdornment={<Map />}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvInput
             required
             inputProps={{ required: false }} // disable default browser behavior
@@ -154,7 +154,7 @@ export default () => {
             onChange={(evt, val) => setValue("password", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvInput
             required
             inputProps={{ required: false }} // disable default browser behavior
@@ -166,7 +166,7 @@ export default () => {
             onChange={(evt, val) => setValue("repeatPassword", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvDatePicker
             name="bday"
             label="Birthday"
@@ -174,14 +174,14 @@ export default () => {
             onChange={(val) => setValue("bday", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <HvTimePicker
             name="startTime"
             label="Start time"
             onChange={(val) => setValue("startTime", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvTextArea
             required
             inputProps={{ required: false }} // disable default browser behavior
@@ -196,7 +196,7 @@ export default () => {
             onChange={(evt, val) => setValue("description", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvRadioGroup
             required
             name="sex"
@@ -211,7 +211,7 @@ export default () => {
             <HvRadio value="other" label="Other" />
           </HvRadioGroup>
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvCheckBox
             defaultChecked
             name="subscribe"
@@ -220,7 +220,7 @@ export default () => {
             onChange={(evt, val) => setValue("subscribe", val)}
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvButton type="submit">Submit</HvButton>
         </HvGrid>
       </HvGrid>

--- a/apps/docs/src/examples/forms/ReactHookForm.tsx
+++ b/apps/docs/src/examples/forms/ReactHookForm.tsx
@@ -133,16 +133,16 @@ export default () => {
       )}
     >
       <HvGrid container maxWidth="md" rowSpacing="xs">
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl control={control} name="name" label="Full Name" />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl control={control} name="email" label="Email" />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl control={control} name="address" label="Address" />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl
             control={control}
             name="country"
@@ -151,7 +151,7 @@ export default () => {
             endAdornment={<Map />}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl
             control={control}
             type="password"
@@ -159,7 +159,7 @@ export default () => {
             label="Password"
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl
             control={control}
             type="password"
@@ -167,7 +167,7 @@ export default () => {
             label="Repeat password"
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <Controller
             control={control}
             name="bday"
@@ -181,7 +181,7 @@ export default () => {
             )}
           />
         </HvGrid>
-        <HvGrid item xs={12} sm={6}>
+        <HvGrid size={{ xs: 12, sm: 6 }}>
           <InputControl
             control={control}
             component={HvTimePicker}
@@ -190,7 +190,7 @@ export default () => {
             // TODO: onchange?
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <InputControl
             control={control}
             component={HvTextArea}
@@ -202,7 +202,7 @@ export default () => {
             maxCharQuantity={128}
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <Controller
             control={control}
             name="sex"
@@ -220,7 +220,7 @@ export default () => {
             )}
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <Controller
             control={control}
             name="subscribe"
@@ -235,7 +235,7 @@ export default () => {
             )}
           />
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvButton type="submit">Submit</HvButton>
         </HvGrid>
       </HvGrid>

--- a/packages/cli/src/baselines/app-shell/vite/src/pages/Example/index.tsx
+++ b/packages/cli/src/baselines/app-shell/vite/src/pages/Example/index.tsx
@@ -12,10 +12,10 @@ const Example = () => {
 
   return (
     <HvGrid container>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvTypography variant="title2">{t("page.title")}</HvTypography>
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvGlobalActions title={t("section.title")} variant="section" />
       </HvGrid>
     </HvGrid>

--- a/packages/core/src/Dialog/stories/FormStory.tsx
+++ b/packages/core/src/Dialog/stories/FormStory.tsx
@@ -13,13 +13,13 @@ import {
 
 const DialogForm = () => (
   <HvGrid container rowSpacing="xs">
-    <HvGrid item xs={12}>
+    <HvGrid size={12}>
       <HvInput required name="author" label="Author" defaultValue="John Doe" />
     </HvGrid>
-    <HvGrid item xs={12}>
+    <HvGrid size={12}>
       <HvInput required name="title" label="Title" autoFocus />
     </HvGrid>
-    <HvGrid item xs={12}>
+    <HvGrid size={12}>
       <HvTextArea name="content" label="Description" rows={4} />
     </HvGrid>
   </HvGrid>

--- a/packages/core/src/Grid/Grid.stories.tsx
+++ b/packages/core/src/Grid/Grid.stories.tsx
@@ -35,31 +35,31 @@ export const Main: StoryObj<HvGridProps> = {
         <br />
         <HvGrid container>
           <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
-            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
+            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
-            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
+            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
-            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
+            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
-            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
+            <StyledItem>xl=2 lg=3 md=4 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 1, lg: 2, md: 3, xs: 12 }}>
-            <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
+            <StyledItem>xl=1 lg=2 md=3 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 1, lg: 2, md: 3, xs: 12 }}>
-            <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
+            <StyledItem>xl=1 lg=2 md=3 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 1, lg: 2, md: 3, xs: 12 }}>
-            <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
+            <StyledItem>xl=1 lg=2 md=3 sm=6 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 3, lg: 3, md: 6, sm: 12, xs: 12 }}>
-            <StyledItem>xl=6 lg=6 md=3 sm=2 xs=1</StyledItem>
+            <StyledItem>xl=3 lg=3 md=6 sm=12 xs=12</StyledItem>
           </HvGrid>
           <HvGrid size={{ xl: 3, lg: 3, md: 6, sm: 12, xs: 12 }}>
-            <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
+            <StyledItem>xl=3 lg=3 md=6 sm=12 xs=12</StyledItem>
           </HvGrid>
         </HvGrid>
       </>

--- a/packages/core/src/Grid/Grid.stories.tsx
+++ b/packages/core/src/Grid/Grid.stories.tsx
@@ -34,31 +34,31 @@ export const Main: StoryObj<HvGridProps> = {
         <HvTypography variant="label">{`Current width: ${width}`}</HvTypography>
         <br />
         <HvGrid container>
-          <HvGrid item xl={2} lg={3} md={4} sm={6} xs={12}>
+          <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
             <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={2} lg={3} md={4} sm={6} xs={12}>
+          <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
             <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={2} lg={3} md={4} sm={6} xs={12}>
+          <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
             <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={2} lg={3} md={4} sm={6} xs={12}>
+          <HvGrid size={{ xl: 2, lg: 3, md: 4, sm: 6, xs: 12 }}>
             <StyledItem>xl=2 lg=3 md=4 sm=6 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={1} lg={2} md={3} xs={12}>
+          <HvGrid size={{ xl: 1, lg: 2, md: 3, xs: 12 }}>
             <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={1} lg={2} md={3} xs={12}>
+          <HvGrid size={{ xl: 1, lg: 2, md: 3, xs: 12 }}>
             <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={1} lg={2} md={3} xs={12}>
+          <HvGrid size={{ xl: 1, lg: 2, md: 3, xs: 12 }}>
             <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={3} lg={3} md={6} sm={12} xs={12}>
+          <HvGrid size={{ xl: 3, lg: 3, md: 6, sm: 12, xs: 12 }}>
             <StyledItem>xl=6 lg=6 md=3 sm=2 xs=1</StyledItem>
           </HvGrid>
-          <HvGrid item xl={3} lg={3} md={6} sm={12} xs={12}>
+          <HvGrid size={{ xl: 3, lg: 3, md: 6, sm: 12, xs: 12 }}>
             <StyledItem>xl=6 lg=4 md=3 sm=2 xs=1</StyledItem>
           </HvGrid>
         </HvGrid>
@@ -94,7 +94,7 @@ export const The12Columns: StoryObj<HvGridProps> = {
         <HvTypography variant="label">{`Current width: ${width} (gutter size: ${BREAKPOINT_GUTTERS[width]})`}</HvTypography>
         <HvGrid container>
           {columns.map((value) => (
-            <HvGrid key={value} item xs={1}>
+            <HvGrid key={value} size={1}>
               <StyledItem>{value.toString()}</StyledItem>
             </HvGrid>
           ))}
@@ -131,7 +131,7 @@ export const TheDesignSystemColumns: StoryObj<HvGridProps> = {
         <HvTypography variant="label">{`Current width: ${width} (${BREAKPOINT_COLUMNS[width]} columns)`}</HvTypography>
         <HvGrid container columns="auto">
           {columns.map((value) => (
-            <HvGrid key={value} item xs={1}>
+            <HvGrid key={value} size={1}>
               <StyledItem>{value.toString()}</StyledItem>
             </HvGrid>
           ))}

--- a/packages/core/src/Grid/Grid.test.tsx
+++ b/packages/core/src/Grid/Grid.test.tsx
@@ -8,4 +8,24 @@ describe("Grid", () => {
     const { container } = render(<HvGrid />);
     expect(container).toBeDefined();
   });
+
+  it("should render a container with explicit size items", () => {
+    const { container } = render(
+      <HvGrid container data-testid="container">
+        <HvGrid size={{ xs: 12, md: 6 }} data-testid="item" />
+      </HvGrid>,
+    );
+
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("should keep compatibility with legacy breakpoint props", () => {
+    const { container } = render(
+      <HvGrid container>
+        <HvGrid xs={12} md={6} data-testid="legacy-item" />
+      </HvGrid>,
+    );
+
+    expect(container.firstChild).toBeTruthy();
+  });
 });

--- a/packages/core/src/Grid/Grid.test.tsx
+++ b/packages/core/src/Grid/Grid.test.tsx
@@ -18,14 +18,4 @@ describe("Grid", () => {
 
     expect(container.firstChild).toBeTruthy();
   });
-
-  it("should keep compatibility with legacy breakpoint props", () => {
-    const { container } = render(
-      <HvGrid container>
-        <HvGrid xs={12} md={6} data-testid="legacy-item" />
-      </HvGrid>,
-    );
-
-    expect(container.firstChild).toBeTruthy();
-  });
 });

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -1,10 +1,7 @@
 import { forwardRef } from "react";
-import MuiGrid, {
-  type GridLegacyProps as MuiGridProps,
-} from "@mui/material/GridLegacy";
+import MuiGrid, { type GridProps as MuiGridProps } from "@mui/material/Grid";
 import { useDefaultProps, type ExtractNames } from "@pentaho/uikit-react-utils";
 
-import { useWidth } from "../hooks/useWidth";
 import { staticClasses, useClasses } from "./Grid.styles";
 
 export { staticClasses as gridClasses };
@@ -51,15 +48,33 @@ export type HvGridSpacing =
   | 9
   | 10;
 
-export interface HvGridProps extends Omit<MuiGridProps, "classes" | "columns"> {
+type HvGridLegacyBreakpointSize = number | boolean;
+
+type HvGridBreakpoint = "xs" | "sm" | "md" | "lg" | "xl";
+
+type HvGridLegacySize = Partial<
+  Record<HvGridBreakpoint, HvGridLegacyBreakpointSize>
+>;
+
+export interface HvGridProps extends Omit<
+  MuiGridProps,
+  "classes" | "columns" | "size"
+> {
   /**
    * If `true`, the component will have the flex *container* behavior.
    * You should be wrapping *items* with a *container*.
    */
   container?: boolean;
   /**
+   * Defines the number of columns the grid item occupies.
+   *
+   * This is the preferred API in MUI Grid.
+   */
+  size?: MuiGridProps["size"];
+  /**
    * If `true`, the component will have the flex *item* behavior.
    * You should be wrapping *items* with a *container*.
+   * @deprecated Grid items are implicit in MUI Grid. This prop has no effect.
    */
   item?: boolean;
   /**
@@ -108,26 +123,31 @@ export interface HvGridProps extends Omit<MuiGridProps, "classes" | "columns"> {
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for all the screen sizes with the lowest priority.
+   * @deprecated Use `size` instead.
    */
   xs?: number | boolean;
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `sm` breakpoint and wider screens if not overridden.
+   * @deprecated Use `size` instead.
    */
   sm?: number | boolean;
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `md` breakpoint and wider screens if not overridden.
+   * @deprecated Use `size` instead.
    */
   md?: number | boolean;
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `lg` breakpoint and wider screens if not overridden.
+   * @deprecated Use `size` instead.
    */
   lg?: number | boolean;
   /**
    * Defines the number of grids the component is going to use.
    * It's applied for the `xl` breakpoint and wider screens.
+   * @deprecated Use `size` instead.
    */
   xl?: number | boolean;
   /**
@@ -138,6 +158,7 @@ export interface HvGridProps extends Omit<MuiGridProps, "classes" | "columns"> {
   /**
    * If `true`, it sets `min-width: 0` on the item.
    * Refer to the limitations section of the documentation to better understand the use case.
+   * @deprecated Use `sx={{ minWidth: 0 }}` instead.
    */
   zeroMinWidth?: boolean;
   /** A Jss Object used to override or extend the styles applied to the component. */
@@ -145,41 +166,85 @@ export interface HvGridProps extends Omit<MuiGridProps, "classes" | "columns"> {
 }
 
 function getGridSpacing(spacing: HvGridProps["spacing"]) {
-  let gridSpacing: MuiGridProps["spacing"];
-
   if (typeof spacing === "string") {
     if (spacing === "auto") {
-      gridSpacing = BREAKPOINT_GUTTERS;
-    } else {
-      gridSpacing = BREAKPOINT_GUTTERS[spacing];
+      return BREAKPOINT_GUTTERS;
     }
-  } else if (typeof spacing === "object") {
-    gridSpacing = Object.keys(spacing).reduce<Record<string, number>>(
-      (acc, bp) => {
-        acc[bp] = BREAKPOINT_GUTTERS[spacing[bp]] ?? spacing[bp];
+
+    return BREAKPOINT_GUTTERS[spacing];
+  } else if (typeof spacing === "object" && !Array.isArray(spacing)) {
+    return Object.keys(spacing).reduce<Record<string, number>>((acc, bp) => {
+      const value = spacing[bp as keyof typeof spacing] as
+        | HvGridSpacing
+        | number
+        | undefined;
+
+      if (value == null) return acc;
+
+      if (typeof value === "number") {
+        acc[bp] = value;
         return acc;
-      },
-      {},
-    );
+      }
+
+      if (value === "auto") {
+        acc[bp] = BREAKPOINT_GUTTERS[bp as keyof typeof BREAKPOINT_GUTTERS];
+        return acc;
+      }
+
+      acc[bp] = BREAKPOINT_GUTTERS[value];
+
+      return acc;
+    }, {});
   } else if (spacing === 0) {
-    gridSpacing = { xs: 0 };
-  } else {
-    gridSpacing = spacing;
+    return { xs: 0 };
   }
 
-  return gridSpacing;
+  return spacing;
 }
 
 function getNumberOfColumns(columns: HvGridProps["columns"]) {
-  let numberOfColumns: MuiGridProps["columns"];
-
   if (columns === "auto") {
-    numberOfColumns = BREAKPOINT_COLUMNS;
-  } else {
-    numberOfColumns = columns;
+    return BREAKPOINT_COLUMNS;
   }
 
-  return numberOfColumns;
+  return columns;
+}
+
+function getGridSize(
+  size: HvGridProps["size"],
+  legacySize: HvGridLegacySize,
+): MuiGridProps["size"] | undefined {
+  if (size != null) return size;
+
+  const responsiveSize = Object.entries(legacySize).reduce<
+    Partial<Record<HvGridBreakpoint, number | "grow">>
+  >((acc, [breakpoint, value]) => {
+    if (value == null || value === false) return acc;
+
+    acc[breakpoint as HvGridBreakpoint] = value === true ? "grow" : value;
+
+    return acc;
+  }, {});
+
+  if (Object.keys(responsiveSize).length === 0) {
+    return undefined;
+  }
+
+  return responsiveSize;
+}
+
+function getSx(
+  zeroMinWidth: HvGridProps["zeroMinWidth"],
+  sx: MuiGridProps["sx"],
+) {
+  if (!zeroMinWidth) {
+    return sx;
+  }
+
+  return [
+    { minWidth: 0 },
+    ...(Array.isArray(sx) ? sx : sx != null ? [sx] : []),
+  ];
 }
 
 function getContainerProps(
@@ -209,28 +274,6 @@ function getContainerProps(
   return containerProps;
 }
 
-const WidthGrid = forwardRef<
-  // no-indent
-  HTMLDivElement,
-  HvGridProps
->(function WidthGrid(props, ref) {
-  const { container, spacing, rowSpacing, columnSpacing, columns, ...others } =
-    props;
-
-  const width = useWidth();
-
-  const containerProps = container
-    ? getContainerProps(
-        spacing === "auto" ? width : spacing,
-        rowSpacing === "auto" ? width : rowSpacing,
-        columnSpacing === "auto" ? width : columnSpacing,
-        columns,
-      )
-    : {};
-
-  return <MuiGrid ref={ref} {...containerProps} {...others} />;
-});
-
 /**
  * The grid creates visual consistency between layouts while allowing flexibility
  * across a wide variety of designs. This component is based on a 12-column grid layout.
@@ -251,40 +294,28 @@ export const HvGrid = forwardRef<
   HvGridProps
 >(function HvGrid(props, ref) {
   const {
-    item,
+    item: _item,
     container,
     spacing = "auto",
     rowSpacing,
     columnSpacing,
     columns,
+    size,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+    justify,
+    justifyContent,
+    zeroMinWidth,
+    sx,
+    className,
     classes: classesProp,
     ...others
   } = useDefaultProps("HvGrid", props);
 
-  const { classes } = useClasses(classesProp);
-
-  // Fixes MUI error when using spacings as objects and the grid is an item and container
-  // When set to "auto", the spacing changes depending on the screen's breakpoint
-  // The condition avoids using useWidth and re-rendering the component unnecessarily
-  if (
-    container &&
-    item &&
-    (spacing === "auto" || rowSpacing === "auto" || columnSpacing === "auto")
-  ) {
-    return (
-      <WidthGrid
-        ref={ref}
-        classes={classes}
-        item={item}
-        container={container}
-        spacing={spacing}
-        rowSpacing={rowSpacing}
-        columnSpacing={columnSpacing}
-        columns={columns}
-        {...others}
-      />
-    );
-  }
+  const { classes, cx } = useClasses(classesProp);
 
   const containerProps = container
     ? getContainerProps(spacing, rowSpacing, columnSpacing, columns)
@@ -293,8 +324,10 @@ export const HvGrid = forwardRef<
   return (
     <MuiGrid
       ref={ref}
-      classes={classes}
-      item={item}
+      className={cx(classes.root, className)}
+      size={getGridSize(size, { xs, sm, md, lg, xl })}
+      justifyContent={justifyContent ?? justify}
+      sx={getSx(zeroMinWidth, sx)}
       {...containerProps}
       {...others}
     />

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -48,14 +48,6 @@ export type HvGridSpacing =
   | 9
   | 10;
 
-type HvGridLegacyBreakpointSize = number | boolean;
-
-type HvGridBreakpoint = "xs" | "sm" | "md" | "lg" | "xl";
-
-type HvGridLegacySize = Partial<
-  Record<HvGridBreakpoint, HvGridLegacyBreakpointSize>
->;
-
 export interface HvGridProps extends Omit<
   MuiGridProps,
   "classes" | "columns" | "size"
@@ -121,36 +113,6 @@ export interface HvGridProps extends Omit<
     | "space-around"
     | "space-evenly";
   /**
-   * Defines the number of grids the component is going to use.
-   * It's applied for all the screen sizes with the lowest priority.
-   * @deprecated Use `size` instead.
-   */
-  xs?: number | boolean;
-  /**
-   * Defines the number of grids the component is going to use.
-   * It's applied for the `sm` breakpoint and wider screens if not overridden.
-   * @deprecated Use `size` instead.
-   */
-  sm?: number | boolean;
-  /**
-   * Defines the number of grids the component is going to use.
-   * It's applied for the `md` breakpoint and wider screens if not overridden.
-   * @deprecated Use `size` instead.
-   */
-  md?: number | boolean;
-  /**
-   * Defines the number of grids the component is going to use.
-   * It's applied for the `lg` breakpoint and wider screens if not overridden.
-   * @deprecated Use `size` instead.
-   */
-  lg?: number | boolean;
-  /**
-   * Defines the number of grids the component is going to use.
-   * It's applied for the `xl` breakpoint and wider screens.
-   * @deprecated Use `size` instead.
-   */
-  xl?: number | boolean;
-  /**
    * Defines the `flex-wrap` style property.
    * It's applied for all screen sizes.
    */
@@ -208,29 +170,6 @@ function getNumberOfColumns(columns: HvGridProps["columns"]) {
   }
 
   return columns;
-}
-
-function getGridSize(
-  size: HvGridProps["size"],
-  legacySize: HvGridLegacySize,
-): MuiGridProps["size"] | undefined {
-  if (size != null) return size;
-
-  const responsiveSize = Object.entries(legacySize).reduce<
-    Partial<Record<HvGridBreakpoint, number | "grow">>
-  >((acc, [breakpoint, value]) => {
-    if (value == null || value === false) return acc;
-
-    acc[breakpoint as HvGridBreakpoint] = value === true ? "grow" : value;
-
-    return acc;
-  }, {});
-
-  if (Object.keys(responsiveSize).length === 0) {
-    return undefined;
-  }
-
-  return responsiveSize;
 }
 
 function getSx(
@@ -301,11 +240,6 @@ export const HvGrid = forwardRef<
     columnSpacing,
     columns,
     size,
-    xs,
-    sm,
-    md,
-    lg,
-    xl,
     justify,
     justifyContent,
     zeroMinWidth,
@@ -325,7 +259,7 @@ export const HvGrid = forwardRef<
     <MuiGrid
       ref={ref}
       className={cx(classes.root, className)}
-      size={getGridSize(size, { xs, sm, md, lg, xl })}
+      size={size}
       justifyContent={justifyContent ?? justify}
       sx={getSx(zeroMinWidth, sx)}
       {...containerProps}

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -59,16 +59,8 @@ export interface HvGridProps extends Omit<
   container?: boolean;
   /**
    * Defines the number of columns the grid item occupies.
-   *
-   * This is the preferred API in MUI Grid.
    */
   size?: MuiGridProps["size"];
-  /**
-   * If `true`, the component will have the flex *item* behavior.
-   * You should be wrapping *items* with a *container*.
-   * @deprecated Grid items are implicit in MUI Grid. This prop has no effect.
-   */
-  item?: boolean;
   /**
    * Defines the space between the type item component. It can only be used on a type container component.
    * Based in the 8x factor defined in the theme, it allows the definition of this factor based on the factor
@@ -233,7 +225,6 @@ export const HvGrid = forwardRef<
   HvGridProps
 >(function HvGrid(props, ref) {
   const {
-    item: _item,
     container,
     spacing = "auto",
     rowSpacing,

--- a/templates/Dashboard/GridPanel.tsx
+++ b/templates/Dashboard/GridPanel.tsx
@@ -14,7 +14,7 @@ export const GridPanel = ({
   isLoading,
   ...others
 }: HvGridProps & { isLoading?: boolean }) => (
-  <HvGrid item {...others}>
+  <HvGrid {...others}>
     <HvLoadingContainer hidden={!isLoading}>
       <HvPanel
         role="region"

--- a/templates/Dashboard/index.tsx
+++ b/templates/Dashboard/index.tsx
@@ -63,7 +63,7 @@ const Dashboard = () => {
 
   return (
     <HvGrid container>
-      <HvGrid item xs={12} display="flex" justifyContent="space-between">
+      <HvGrid display="flex" justifyContent="space-between" size={12}>
         <HvTypography component="h1" variant="title3">
           Dashboard
         </HvTypography>
@@ -81,7 +81,7 @@ const Dashboard = () => {
           </HvButton>
         </div>
       </HvGrid>
-      <GridPanel xs={12} md={8} isLoading={isLoading}>
+      <GridPanel size={{ xs: 12, md: 8 }} isLoading={isLoading}>
         <HvBarChart
           horizontal
           stack="Group"
@@ -95,7 +95,7 @@ const Dashboard = () => {
           groupBy="Group"
         />
       </GridPanel>
-      <GridPanel xs={12} md={4} isLoading={isLoading}>
+      <GridPanel size={{ xs: 12, md: 4 }} isLoading={isLoading}>
         <div className={css({ position: "relative", height: "100%" })}>
           <HvDonutChart
             data={data.donutData}
@@ -122,11 +122,11 @@ const Dashboard = () => {
         </div>
       </GridPanel>
       {[1, 2, 3, 4].map((key) => (
-        <HvGrid key={key} item xs={6} md={3}>
+        <HvGrid key={key} size={{ xs: 6, md: 3 }}>
           <Kpi color="positive" title="KPI description" value={3340} />
         </HvGrid>
       ))}
-      <GridPanel xs={12} isLoading={isLoading}>
+      <GridPanel size={12} isLoading={isLoading}>
         <HvLineChart
           area
           stack="total"
@@ -137,7 +137,12 @@ const Dashboard = () => {
           tooltip={{ valueFormatter: formatter }}
         />
       </GridPanel>
-      <GridPanel xs={12} md={6} width="100%" height={400} isLoading={isLoading}>
+      <GridPanel
+        size={{ xs: 12, md: 6 }}
+        width="100%"
+        height={400}
+        isLoading={isLoading}
+      >
         <MapComponent
           center={[38.7356, -9.2997]}
           zoom={18}
@@ -149,7 +154,7 @@ const Dashboard = () => {
           ]}
         />
       </GridPanel>
-      <GridPanel xs={12} md={6} height={400} isLoading={isLoading}>
+      <GridPanel size={{ xs: 12, md: 6 }} height={400} isLoading={isLoading}>
         <HvBarChart
           height={400}
           data={data.barData2}

--- a/templates/DetailsView/KPIs.tsx
+++ b/templates/DetailsView/KPIs.tsx
@@ -40,7 +40,7 @@ export const KPIs = () => {
 
   return (
     <>
-      <HvGrid item xs={12} md={2} lg={2}>
+      <HvGrid size={{ xs: 12, md: 2, lg: 2 }}>
         <HvAvatar
           size="xl"
           status="border"
@@ -49,15 +49,15 @@ export const KPIs = () => {
           alt="Asset image"
         />
       </HvGrid>
-      <HvGrid item xs={12} md={10} lg={10}>
+      <HvGrid size={{ xs: 12, md: 10, lg: 10 }}>
         <HvGrid container direction="row">
           {deploys.summary.map((el) => (
-            <HvGrid key={el.id} item xs={12} sm={4}>
+            <HvGrid key={el.id} size={{ xs: 12, sm: 4 }}>
               <Kpi title={el.title} count={el.count} diff={el.diff} />
             </HvGrid>
           ))}
           {deploys.data.map((el) => (
-            <HvGrid key={el.id} item xs={12} sm={4}>
+            <HvGrid key={el.id} size={{ xs: 12, sm: 4 }}>
               <MetadataItem title={el.title}>
                 <HvTypography variant="caption1">{el.value}</HvTypography>
               </MetadataItem>

--- a/templates/DetailsView/MetadataItem.tsx
+++ b/templates/DetailsView/MetadataItem.tsx
@@ -16,7 +16,7 @@ export const MetadataItem = ({
   children,
   ...others
 }: MetadataItemProps) => (
-  <HvGrid item {...others}>
+  <HvGrid {...others}>
     <div
       role="group"
       className={css({

--- a/templates/DetailsView/Properties.tsx
+++ b/templates/DetailsView/Properties.tsx
@@ -45,7 +45,7 @@ const entries: Partial<
 > = {
   description: {
     label: "Description",
-    sm: 6,
+    size: { sm: 6 },
     EditComponent: ({ value }) => (
       <HvTextArea name="description" rows={3} defaultValue={value} />
     ),
@@ -116,7 +116,12 @@ export const Properties = ({ editMode }: { editMode?: boolean }) => {
     const ContentComponent = (editMode && EditComponent) || Component;
 
     return (
-      <MetadataItem key={key} xs={12} sm={3} title={label} {...others}>
+      <MetadataItem
+        key={key}
+        size={{ xs: 12, sm: 3 }}
+        title={label}
+        {...others}
+      >
         {(ContentComponent && <ContentComponent value={value} />) ||
           (value as any)}
       </MetadataItem>

--- a/templates/DetailsView/index.tsx
+++ b/templates/DetailsView/index.tsx
@@ -89,7 +89,7 @@ const DetailsView = () => {
       </Section>
 
       <Section title="Events">
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <Table modelId={MODEL_ID} />
         </HvGrid>
       </Section>

--- a/templates/Form/index.tsx
+++ b/templates/Form/index.tsx
@@ -31,16 +31,16 @@ const Form = () => (
     }}
   >
     <HvGrid container maxWidth="md" rowSpacing="xs">
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput required name="name" label="Full Name" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput required type="email" name="email" label="Email" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput name="street-address" label="Address" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvSelect
           required
           name="country"
@@ -54,21 +54,21 @@ const Form = () => (
           ))}
         </HvSelect>
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput name="tel" label="Phone number" endAdornment={<Phone />} />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvInput type="password" name="password" label="Password" />
       </HvGrid>
-      <HvGrid item xs={12} component="hr" />
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid component="hr" size={12} />
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvDatePicker name="bday" label="Birthday" placeholder="Select date" />
       </HvGrid>
-      <HvGrid item xs={12} sm={6}>
+      <HvGrid size={{ xs: 12, sm: 6 }}>
         <HvTimePicker name="startTime" label="Start time" />
       </HvGrid>
-      <HvGrid item xs={12} component="hr" />
-      <HvGrid item xs={12}>
+      <HvGrid component="hr" size={12} />
+      <HvGrid size={12}>
         <HvTextArea
           required
           name="description"
@@ -80,14 +80,14 @@ const Form = () => (
           maxCharQuantity={128}
         />
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvRadioGroup required name="sex" label="Sex" orientation="horizontal">
           <HvRadio value="male" label="Male" />
           <HvRadio value="female" label="Female" />
           <HvRadio value="other" label="Other" />
         </HvRadioGroup>
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvCheckBox
           defaultChecked
           name="subscribe"
@@ -95,7 +95,7 @@ const Form = () => (
           value="yes"
         />
       </HvGrid>
-      <HvGrid item xs={12}>
+      <HvGrid size={12}>
         <HvButton type="submit">Submit</HvButton>
       </HvGrid>
     </HvGrid>

--- a/templates/Welcome/index.tsx
+++ b/templates/Welcome/index.tsx
@@ -31,22 +31,22 @@ const Welcome = () => {
   return (
     <div className={classes.root}>
       <HvGrid container>
-        <HvGrid item xs={6}>
+        <HvGrid size={6}>
           <HvGrid container>
-            <HvGrid item xs={8}>
+            <HvGrid size={8}>
               <HvTypography variant="title1">Welcome to UI Kit</HvTypography>
             </HvGrid>
-            <HvGrid item xs={8}>
+            <HvGrid size={8}>
               <HvTypography variant="label">
                 UI Kit is a composable and accessible component library that
                 gives you the foundation to build your application faster and
                 consistently.
               </HvTypography>
             </HvGrid>
-            <HvGrid item xs={8}>
+            <HvGrid size={8}>
               <HvInput type="search" placeholder="What are you looking for?" />
             </HvGrid>
-            <HvGrid item xs={6}>
+            <HvGrid size={6}>
               <div className={classes.glossaryContainer}>
                 <Palette iconSize="M" />
                 <HvTypography variant="title4" component="p">
@@ -58,7 +58,7 @@ const Welcome = () => {
                 </HvTypography>
               </div>
             </HvGrid>
-            <HvGrid item xs={6}>
+            <HvGrid size={6}>
               <div className={classes.glossaryContainer}>
                 <Heart iconSize="M" />
                 <HvTypography variant="title4" component="p">
@@ -72,7 +72,7 @@ const Welcome = () => {
             </HvGrid>
           </HvGrid>
         </HvGrid>
-        <HvGrid item xs={6} display="flex">
+        <HvGrid display="flex" size={6}>
           <div className={classes.imageContainer}>
             <img
               alt="Monitor showing a dashboard built with UI Kit components"
@@ -80,7 +80,7 @@ const Welcome = () => {
             />
           </div>
         </HvGrid>
-        <HvGrid item xs={12}>
+        <HvGrid size={12}>
           <HvTypography
             link
             component="a"


### PR DESCRIPTION
- Migrated HvGrid internals from MUI GridLegacy to the current MUI Grid.
- Kept the existing HvGrid value-adds for spacing and columns behavior.
- Removed legacy consumer API on HvGrid:
  - removed breakpoint props xs, sm, md, lg, xl
  - removed reliance on item usage patterns
- Standardized usage to the size prop across app/docs/templates touched in this branch.
- Updated Grid docs and stories to use size-based examples.
- Updated Grid unit tests to reflect the new API direction.
- Updated internal template/examples call sites that still depended on legacy breakpoint props.