### PR TITLE
docs: remove old docs URL & HV tags

### DIFF
--- a/packages/app-shell-events/README.md
+++ b/packages/app-shell-events/README.md
@@ -15,4 +15,4 @@ The App Shell Events is available as an NPM package, and can be installed with:
 npm install @pentaho/app-shell-events
 ```
 
-More info about App Shell events is available in https://github.com/lumada-design/hv-app-shell/blob/main/docs/notifications.md#notifications and https://github.com/lumada-design/hv-app-shell/blob/main/docs/theming.md#triggering-color-mode-change.
+More info about App Shell events is available in https://pentaho.github.io/uikit-docs/master/app-shell/api-reference

--- a/packages/app-shell-ui/README.md
+++ b/packages/app-shell-ui/README.md
@@ -18,4 +18,4 @@ The App Shell is available as an NPM package, and can be installed with:
 npm install @pentaho/app-shell-ui
 ```
 
-Setup instructions for the App Shell are available in https://github.com/lumada-design/hv-app-shell.
+Setup instructions for the App Shell are available in https://pentaho.github.io/uikit-docs/master/app-shell/installation.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,6 @@
     "uikit-cli": "src/index.js"
   },
   "keywords": [
-    "hitachivantara",
     "uikit-cli",
     "cli"
   ],

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -4,11 +4,10 @@
   "type": "module",
   "private": false,
   "author": "UI Kit Team",
-  "description": "A wrapper to the React Monaco editor (https://github.com/react-monaco-editor/react-monaco-editor) using the Design System styles.",
+  "description": "A wrapper to the React Monaco Editor using the Design System styles.",
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "react",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,13 +8,12 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "config",
     "ui-kit"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pentaho/hv-uikit-react.git",
+    "url": "git+https://github.com/pentaho/hv-uikit-react.git",
     "directory": "packages/config"
   },
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "react",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "react",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "react",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "typescript"

--- a/packages/uno-preset/package.json
+++ b/packages/uno-preset/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "typescript",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "react",

--- a/packages/viz/package.json
+++ b/packages/viz/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "design-system",
     "ui-kit",
     "react",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -8,7 +8,6 @@
   "homepage": "https://github.com/pentaho/hv-uikit-react",
   "sideEffects": false,
   "keywords": [
-    "hitachi-vantara",
     "ui-kit",
     "typescript",
     "pentaho"


### PR DESCRIPTION
remove HV npm `keywords` & old `lumada-design` doc URLs