### PR TITLE
fix(uno): keep existing min/max width breakpoints

### DIFF
--- a/packages/uno-preset/src/theme.ts
+++ b/packages/uno-preset/src/theme.ts
@@ -25,8 +25,14 @@ export const extendTheme: ThemeExtender<Theme> = (baseTheme) => ({
     ...theme.radii,
   },
   breakpoints: Object.fromEntries(hvBreakpoints),
-  maxWidth: Object.fromEntries(hvBreakpoints),
-  minWidth: Object.fromEntries(hvBreakpoints),
+  maxWidth: {
+    ...baseTheme.maxWidth,
+    ...Object.fromEntries(hvBreakpoints),
+  },
+  minWidth: {
+    ...baseTheme.minWidth,
+    ...Object.fromEntries(hvBreakpoints),
+  },
   containers: Object.fromEntries(
     hvBreakpoints.map(([k, v]) => [k, `(min-width: ${v})`]),
   ),


### PR DESCRIPTION
this allows using values such as `max-w-4xl`.
although we don't recommend it, we strive to keep tailwind compat