### PR TITLE
chore: ignore generated changelogs in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
## Problem

`Tests / Static Checks` fails at **Run Format** on 5 `CHANGELOG.md` files. Red on the nightly since `30beb79a6 chore(release): publish` (2026-08-24), and every PR opened since fails the same way — CI checks out the merge ref, so master's changelogs come along.

## Cause

lerna-lite writes changelog bullets as `*`; prettier normalises them to `-`. Introduced by `87704d77f` (#5201, migrate to lerna-lite): every release before it wrote `-`, every release after writes `*`. It went unnoticed because the release bot commits straight to master and nothing runs Static Checks on push.

## Fix

```
CHANGELOG.md
```

Generated files shouldn't be style-gated. No content changes — once ignored, the existing bullets stop failing.

Changing the preset instead wouldn't help: the bullet is hardcoded in the conventional-changelog handlebars template, not an option, so it would mean maintaining a custom preset.

## Verification

`npm run prettier` exit 0 (was 1), `npm run lint` 0 errors. Unblocks the nightly and every open PR. Next release cron is 2026-09-15.