### PR TITLE
fix(config): restore prettier plugin dependency

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,6 +29,10 @@
     "./oxlint/*.json": "./oxlint/*.json",
     "./tsconfig": "./tsconfig.json"
   },
+  "peerDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
+    "prettier": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Problem

`@hitachivantara/uikit-config` 0.6.3+ doesn't ship `@ianvs/prettier-plugin-sort-imports`, so `npm run prettier` fails for consumers:

```
[error] Cannot find package '@ianvs/prettier-plugin-sort-imports' imported from /.../noop.js
```

`prettier.config.json` declares the plugin, but nothing installs it.

## Cause

#5173 removed peers in `packages/config`.

## Fix

Restores both peers (plugin version bumped to match the repo root). 