### PR TITLE
chore: sync master into next

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/apps/default-app/app-shell.config.ts
+++ b/apps/default-app/app-shell.config.ts
@@ -32,24 +32,24 @@ export default {
         {
           label: "asset",
           icon: {
-            iconType: "uikit",
-            name: "Desktop",
+            iconType: "unocss",
+            name: "i-ph-desktop",
           },
           submenus: [
             {
               label: "asset",
               target: "/asset-inventory",
               icon: {
-                iconType: "uikit",
-                name: "Cards",
+                iconType: "unocss",
+                name: "i-ph-cards",
               },
             },
             {
               label: "list",
               target: "/list-view",
               icon: {
-                iconType: "uikit",
-                name: "List",
+                iconType: "unocss",
+                name: "i-ph-list",
               },
             },
           ],
@@ -58,16 +58,16 @@ export default {
           label: "asset",
           target: "/asset-inventory",
           icon: {
-            iconType: "uikit",
-            name: "Cards",
+            iconType: "unocss",
+            name: "i-ph-cards",
           },
         },
         {
           label: "list",
           target: "/list-view",
           icon: {
-            iconType: "uikit",
-            name: "List",
+            iconType: "unocss",
+            name: "i-ph-list",
           },
         },
         {
@@ -83,8 +83,8 @@ export default {
           label: "Theming",
           target: "/theming",
           icon: {
-            iconType: "uikit",
-            name: "ColorPicker",
+            iconType: "unocss",
+            name: "i-ph-eyedropper",
           },
         },
         ...Array.from(Array(16).keys()).map((i) => ({
@@ -95,8 +95,8 @@ export default {
           label: "Services Demo",
           target: "/services-demo",
           icon: {
-            iconType: "uikit",
-            name: "Settings",
+            iconType: "unocss",
+            name: "i-ph-gear",
           },
         },
       ],
@@ -105,8 +105,8 @@ export default {
       label: "Providers Demo",
       target: "/providers-demo",
       icon: {
-        iconType: "uikit",
-        name: "Package",
+        iconType: "unocss",
+        name: "i-ph-package",
       },
     },
     // ========================================
@@ -116,72 +116,72 @@ export default {
     {
       label: "Conditions Demo",
       icon: {
-        iconType: "uikit",
-        name: "Eye",
+        iconType: "unocss",
+        name: "i-ph-eye",
       },
       submenus: [
         {
           label: "Sync True (Always Visible)",
           target: "/sync-true-demo",
           icon: {
-            iconType: "uikit",
-            name: "Check",
+            iconType: "unocss",
+            name: "i-ph-check",
           },
         },
         {
           label: "Sync False (Always Hidden)",
           target: "/sync-false-demo",
           icon: {
-            iconType: "uikit",
-            name: "Close",
+            iconType: "unocss",
+            name: "i-ph-x",
           },
         },
         {
           label: "Async True (0.5s delay)",
           target: "/async-true-demo",
           icon: {
-            iconType: "uikit",
-            name: "Clock",
+            iconType: "unocss",
+            name: "i-ph-clock",
           },
         },
         {
           label: "Async False (0.5s delay)",
           target: "/async-false-demo",
           icon: {
-            iconType: "uikit",
-            name: "ClockStop",
+            iconType: "unocss",
+            name: "i-ph-clock-countdown",
           },
         },
         {
           label: "Dynamic (Appears after 10s)",
           target: "/dynamic-condition-demo",
           icon: {
-            iconType: "uikit",
-            name: "Refresh",
+            iconType: "unocss",
+            name: "i-ph-arrows-clockwise",
           },
         },
         {
           label: "Sync True + Async True",
           target: "/multiple-conditions-demo",
           icon: {
-            iconType: "uikit",
-            name: "Hierarchy",
+            iconType: "unocss",
+            name: "i-ph-tree-structure",
           },
         },
         {
           label: "Sync True + Sync False",
           target: "/multiple-fail-demo",
           icon: {
-            iconType: "uikit",
-            name: "Ban",
+            iconType: "unocss",
+            name: "i-ph-prohibit",
           },
         },
         {
           label: "Inverse Dynamic (view) + Async True",
           target: "/inverse-dynamic",
           icon: {
-            iconType: "uikit",
-            name: "Ban",
+            iconType: "unocss",
+            name: "i-ph-prohibit",
           },
           conditions: [
             {
@@ -192,8 +192,8 @@ export default {
         {
           label: "Nested Submenus",
           icon: {
-            iconType: "uikit",
-            name: "Tree",
+            iconType: "unocss",
+            name: "i-ph-tree-view",
           },
           submenus: [
             {
@@ -214,8 +214,8 @@ export default {
         {
           label: "Disappearing Parent (10s)",
           icon: {
-            iconType: "uikit",
-            name: "Disappear",
+            iconType: "unocss",
+            name: "i-ph-eye-slash",
           },
           submenus: [
             {

--- a/apps/default-app/app-shell.config.ts
+++ b/apps/default-app/app-shell.config.ts
@@ -502,6 +502,9 @@ export default {
       // Always visible provider (no conditions)
     },
     {
+      bundle: "$app/FailsToLoadAndAppDoesntBreak.js",
+    },
+    {
       bundle: "$app/providers/AsyncProvider.js",
       conditions: [{ bundle: "$app/conditions/useAsyncTrue.js" }],
     },

--- a/apps/default-app/vite.config.ts
+++ b/apps/default-app/vite.config.ts
@@ -38,8 +38,6 @@ export default defineConfig(({ mode }) => ({
         "src/conditions/useAsyncFalse",
         "src/conditions/useFlipToTrue",
         "src/conditions/useFlipToFalse",
-        "src/pages/ShouldBeVisible",
-        "src/pages/ShouldNotBeVisible",
       ],
     }),
   ],

--- a/apps/docs/src/content/components/vertical-navigation.mdx
+++ b/apps/docs/src/content/components/vertical-navigation.mdx
@@ -12,208 +12,168 @@ import { Header } from "../../components/Header";
 
 > [!NOTE]
 >
-> Use mode="disclosure" for most apps. Avoid mode="treeview" unless complex
-> hierarchy and custom keyboard interaction are required.
+> The tree defaults to `mode="disclosure"`, which suits most apps. Set
+> `mode="treeview"` for arrow-key navigation — it overrides standard keyboard
+> behavior, so only use it when the hierarchy genuinely needs it.
 
 ### Usage
 
-The example below demonstrates a typical use of the `VerticalNavigation` component, combining `VerticalNavigationTree` to render the navigation structure and `VerticalNavigationActions` to display bottom-aligned actions.
+`HvVerticalNavigationTree` renders a `data` array; `HvVerticalNavigationActions` pins actions to the bottom. Each child is separated by a divider, so grouping is a matter of how you nest them.
 
 ```tsx live
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 export default function Demo() {
-  const [value, setValue] = useState("00");
+  const [selected, setSelected] = useState("analytics-reports");
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(true);
+  const searchRef = useRef(null);
+
+  const sections = useMemo(
+    () => filterNavigation(mainSections, query),
+    [query],
+  );
+
+  const treeProps = {
+    selected,
+    onChange: (event, data) => setSelected(data.id),
+  };
+
+  // on the collapsed rail the field becomes an icon that reopens the navigation
+  const openSearch = () => {
+    setOpen(true);
+    requestAnimationFrame(() => searchRef.current?.focus());
+  };
 
   return (
-    <HvVerticalNavigation>
+    <HvVerticalNavigation open={open} useIcons>
       <HvVerticalNavigationTree
-        aria-label="Example 1 navigation"
-        selected={value}
-        onChange={(event, data) => {
-          if (data.id === "02-01-01") {
-            event.preventDefault();
-            event.stopPropagation();
-          }
-          setValue(data.id);
-        }}
-        data={navigationData}
+        aria-label="Quick access"
+        data={quickAccess}
+        {...treeProps}
       />
+      <section className="flex flex-col gap-sm">
+        {open ? (
+          <HvSearchInput
+            ref={searchRef}
+            aria-label="Menu search"
+            placeholder="Menu search..."
+            value={query}
+            onChange={(event, value) => setQuery(value)}
+          />
+        ) : (
+          <HvIconButton
+            title="Menu search"
+            onClick={openSearch}
+            // minimized tree items center themselves; match them
+            style={{ alignSelf: "center" }}
+          >
+            {/* the button resets the color the nav sets on its children */}
+            <Search color="textLight" />
+          </HvIconButton>
+        )}
+        <HvVerticalNavigationTree
+          // remounting re-applies defaultExpanded, so matches open on their own
+          key={query}
+          collapsible
+          aria-label="Sections"
+          defaultExpanded={query ? true : ["analytics"]}
+          data={sections}
+          {...treeProps}
+        />
+      </section>
       <HvVerticalNavigationActions>
-        <HvVerticalNavigationAction label="Profile" icon={<User />} />
-        <HvVerticalNavigationAction label="Logout" icon={<LogOut />} />
+        <HvVerticalNavigationAction
+          label={open ? "Collapse menu" : "Expand menu"}
+          icon={open ? <Backwards /> : <Forwards />}
+          onClick={() => setOpen((prev) => !prev)}
+        />
       </HvVerticalNavigationActions>
     </HvVerticalNavigation>
   );
 }
 
-const navigationData = [
-  { id: "00", label: "Overview" },
-  { id: "01", label: "Analytics" },
-  {
-    id: "02",
-    label: "Storage",
-    data: [
-      {
-        id: "02-01",
-        label: "Cloud",
-        data: [
-          {
-            id: "02-01-01",
-            label: "Servers",
-            href: "https://example.com/servers.html",
-          },
-          {
-            id: "02-01-02",
-            label: "HCP Anywhere",
-          },
-          {
-            id: "02-01-03",
-            label: "This Computer",
-            disabled: true,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    id: "03",
-    label: "Administration",
-    href: "#admin",
-    data: [
-      {
-        id: "03-01",
-        label: "Rest API",
-        href: "#admin-rest",
-        data: [
-          {
-            id: "03-01-01",
-            label: "Log Bundle",
-            href: "#admin-rest-logs",
-          },
-        ],
-      },
-    ],
-  },
+/** Keeps matching items, and parents that still have a matching child. */
+const filterNavigation = (items, query) => {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+
+  return items.flatMap((item) => {
+    const children = item.data ? filterNavigation(item.data, q) : [];
+
+    if (children.length > 0) return [{ ...item, data: children }];
+    if (item.label.toLowerCase().includes(q))
+      return [{ ...item, data: undefined }];
+    return [];
+  });
+};
+
+const quickAccess = [
+  { id: "home", label: "Home", icon: <Home /> },
+  { id: "marketplace", label: "Data Marketplace", icon: <Storage /> },
+  { id: "favorites", label: "Favorites", icon: <Favorite /> },
 ];
-```
 
-### Tree view
-
-Use `mode="treeview"` to enable keyboard navigation with arrow keys. Press Enter to expand/collapse or select items. Set `collapsible` to `true` to allow collapsing non-leaf nodes.
-
-```tsx live
-import { useState } from "react";
-
-export default function Demo() {
-  const [value, setValue] = useState("01-01");
-
-  return (
-    <HvVerticalNavigation>
-      <HvVerticalNavigationTree
-        mode="treeview"
-        collpasible
-        defaultExpanded
-        aria-label="Example 3 navigation"
-        selected={value}
-        onChange={(event, data) => setValue(data.id)}
-        data={navigationData}
-      />
-      <HvVerticalNavigationActions>
-        <HvVerticalNavigationAction label="Profile" icon={<User />} />
-        <HvVerticalNavigationAction label="Logout" icon={<LogOut />} />
-      </HvVerticalNavigationActions>
-    </HvVerticalNavigation>
-  );
-}
-
-const navigationData = [
-  { id: "00", label: "Installation Overview" },
+const mainSections = [
+  { id: "explore", label: "Explore", icon: <Map /> },
+  { id: "transform", label: "Transform", icon: <Machine /> },
+  { id: "governance", label: "Data Governance", icon: <Lock /> },
   {
-    id: "01",
-    label: "Hardware",
+    id: "analytics",
+    label: "Business Analytics",
+    icon: <BarChart />,
     data: [
+      { id: "analytics-models", label: "Semantic Models", icon: <DataStore /> },
+      { id: "analytics-reports", label: "Business Reports", icon: <Doc /> },
       {
-        id: "01-01",
-        label: "Ambient Monitoring",
-      },
-      {
-        id: "01-02",
-        label: "Server Status Summary",
+        id: "analytics-dashboards",
+        label: "Business Dashboards",
+        icon: <LineChart />,
       },
     ],
   },
-  {
-    id: "02",
-    label: "System",
-    data: [
-      {
-        id: "02-01",
-        label: "Buckets",
-      },
-      {
-        id: "02-02",
-        label: "Admin Users",
-      },
-      {
-        id: "02-03",
-        label: "Log Bundle",
-        data: [
-          {
-            id: "02-03-01",
-            label: "Rest API",
-          },
-          {
-            id: "02-03-02",
-            label: "License",
-          },
-        ],
-      },
-    ],
-  },
+  { id: "management", label: "Management", icon: <Deploy /> },
+  { id: "monitoring", label: "Monitoring", icon: <Preview /> },
+  { id: "settings", label: "Settings", icon: <Settings /> },
 ];
 ```
 
 ### Collapsible
 
-To make the navigation collapsible, use `HvVerticalNavigationHeader` with a collapse button. Control the open state via the `open` prop and show the button by passing a handler to `onCollapseButtonClick`.
+Use `HvVerticalNavigationHeader` with `onCollapseButtonClick` to add a collapse button, and `useIcons` to show icons when collapsed. Items without an `icon` show the first letter of their label.
 
-Enable `useIcons` to display icons when collapsed—defaults to the first letter of the label if no icon is provided.
+When collapsed, items with `data` open their children in a popup: hover to open it, click to keep it open. Items without `data` are selected on click.
 
 ```tsx live
 import { useState } from "react";
 
 export default function Demo() {
-  const [value, setValue] = useState("01-01");
-  const [show, setShow] = useState(false);
-  const [icons, setIcons] = useState(false);
-
-  const handleIsExpanded = () => {
-    setShow(!show);
-  };
+  const [selected, setSelected] = useState("analytics-reports");
+  const [open, setOpen] = useState(true);
+  const [icons, setIcons] = useState(true);
 
   return (
-    <div className="flex gap-xs" style={{ height: 400 }}>
+    <div className="flex gap-sm">
       <HvCheckBox
-        label="Show Icons"
+        label="Show icons"
         checked={icons}
-        onChange={() => setIcons(!icons)}
+        onChange={() => setIcons((prev) => !prev)}
       />
-      <HvVerticalNavigation open={show} useIcons={icons}>
+      <HvVerticalNavigation open={open} useIcons={icons}>
         <HvVerticalNavigationHeader
           title="Menu"
-          onCollapseButtonClick={handleIsExpanded}
+          onCollapseButtonClick={() => setOpen((prev) => !prev)}
           collapseButtonProps={{
-            "aria-label": "collapseButton",
-            "aria-expanded": show,
+            "aria-label": "Toggle menu",
+            "aria-expanded": open,
           }}
         />
         <HvVerticalNavigationTree
           collapsible
-          defaultExpanded
-          aria-label="Example 3 navigation"
-          selected={value}
-          onChange={(event, data) => setValue(data.id)}
+          defaultExpanded={["analytics"]}
+          aria-label="Sections"
+          selected={selected}
+          onChange={(event, data) => setSelected(data.id)}
           data={navigationData}
         />
       </HvVerticalNavigation>
@@ -222,75 +182,39 @@ export default function Demo() {
 }
 
 const navigationData = [
-  { id: "00", label: "Installation Overview", icon: <Open /> },
+  { id: "explore", label: "Explore", icon: <Map /> },
   {
-    id: "01",
-    label: "Hardware",
+    id: "analytics",
+    label: "Business Analytics",
     icon: <BarChart />,
     data: [
-      { id: "01-01", label: "Ambient Monitoring", icon: <BarChart /> },
-      { id: "01-02", label: "Server Status Summary" },
+      { id: "analytics-models", label: "Semantic Models", icon: <DataStore /> },
+      { id: "analytics-reports", label: "Business Reports", icon: <Doc /> },
     ],
   },
-  {
-    id: "02",
-    label: "System",
-    icon: <Deploy />,
-    data: [
-      { id: "02-01", label: "Buckets", icon: <Deploy /> },
-      { id: "02-02", label: "Admin Users" },
-      {
-        id: "02-03",
-        label: "Log Bundle",
-        data: [
-          { id: "02-03-01", label: "Rest API" },
-          { id: "02-03-02", label: "License" },
-        ],
-      },
-    ],
-  },
-  {
-    id: "03",
-    label: "System 2",
-    data: [
-      { id: "03-01", label: "Buckets" },
-      { id: "03-02", label: "Admin Users" },
-      {
-        id: "03-03",
-        label: "Log Bundle",
-        data: [
-          { id: "03-03-01", label: "Rest API" },
-          { id: "03-03-02", label: "License" },
-        ],
-      },
-    ],
-  },
+  { id: "management", label: "Management", icon: <Deploy /> },
+  { id: "settings", label: "Settings" },
 ];
 ```
 
 ### Slider
 
-If you set the `slider` prop to `true`, the navigation will be displayed as a slider instead of a tree. When the user selects an item that contains
-children, the content of the navigation will be replaced with the children of the selected item.
-
-You can use this functionality to display the navigation in regular tree view mode and switch to slider mode when the
-screen size is lower that a certain threshold.
+`slider` replaces the content with an item's children instead of expanding in place, one level at a time. Use it when the screen is too narrow for a nested tree.
 
 ```tsx live
 import { useState } from "react";
 
 export default function Demo() {
-  const [value, setValue] = useState("menu1-3");
+  const [selected, setSelected] = useState("explore");
 
   return (
-    <HvVerticalNavigation open slider>
+    <HvVerticalNavigation open slider useIcons>
       <HvVerticalNavigationHeader title="Menu" />
       <HvVerticalNavigationTree
         collapsible
-        defaultExpanded
-        aria-label="Example 4 Slider Mode"
-        selected={value}
-        onChange={(event, data) => setValue(data.id)}
+        aria-label="Sections"
+        selected={selected}
+        onChange={(event, data) => setSelected(data.id)}
         data={navigationData}
       />
     </HvVerticalNavigation>
@@ -298,77 +222,32 @@ export default function Demo() {
 }
 
 const navigationData = [
+  { id: "explore", label: "Explore", icon: <Map /> },
   {
-    id: "menu1",
-    label: "Menu 1",
-    path: "",
-    icon: <Open />,
+    id: "analytics",
+    label: "Business Analytics",
+    icon: <BarChart />,
     data: [
       {
-        id: "menu1-1",
-        label: "Menu 1-1",
-        path: "",
-        icon: <Open />,
-        parent: null,
-      },
-      {
-        id: "menu1-2",
-        label: "Menu 1-2",
-        path: "",
-        icon: <BarChart />,
+        id: "analytics-models",
+        label: "Semantic Models",
+        icon: <DataStore />,
         data: [
-          {
-            id: "menu1-2-1",
-            label: "Menu 1-2-1",
-            path: "",
-            icon: <Open />,
-            parent: null,
-          },
-          {
-            id: "menu1-2-2",
-            label: "Menu 1-2-2",
-            path: "",
-            icon: <BarChart />,
-            parent: null,
-          },
-          {
-            id: "menu1-2-3",
-            label: "Menu 1-2-3",
-            path: "",
-            icon: <Deploy />,
-            parent: null,
-          },
+          { id: "analytics-models-sales", label: "Sales" },
+          { id: "analytics-models-inventory", label: "Inventory" },
         ],
-        parent: null,
       },
-      {
-        id: "menu1-3",
-        label: "Menu 1-3",
-        path: "",
-        icon: <Deploy />,
-        parent: null,
-      },
+      { id: "analytics-reports", label: "Business Reports", icon: <Doc /> },
     ],
-    parent: null,
   },
-  {
-    id: "menu2",
-    label: "Menu 2 with a very big name that should be truncated",
-    path: "",
-    icon: <BarChart />,
-    parent: null,
-  },
-  {
-    id: "menu3",
-    label: "Menu 3",
-    path: "",
-    icon: <Deploy />,
-    parent: null,
-  },
+  { id: "management", label: "Management", icon: <Deploy /> },
+  { id: "settings", label: "Settings" },
 ];
 ```
 
 ### Custom content
+
+`HvVerticalNavigation` accepts arbitrary children, so branding or a primary action can sit alongside the tree.
 
 ```tsx live
 import { useState } from "react";
@@ -397,29 +276,19 @@ export default function Demo() {
           label="Create"
         />
       </div>
-      <HvVerticalNavigationTree data={data} />
+      <HvVerticalNavigationTree aria-label="Sections" data={navigationData} />
       <HvVerticalNavigationActions>
-        <div className="relative">
-          {!collapsed && (
-            <Backwards className="absolute pointer-events-none top-0 right-0" />
-          )}
-          <HvVerticalNavigationAction
-            label={collapsed ? "Expand menu" : "Collapse menu"}
-            icon={collapsed ? <Forwards /> : undefined}
-            onClick={() => setCollapsed((prev) => !prev)}
-          />
-        </div>
+        <HvVerticalNavigationAction
+          label={collapsed ? "Expand menu" : "Collapse menu"}
+          icon={collapsed ? <Forwards /> : <Backwards />}
+          onClick={() => setCollapsed((prev) => !prev)}
+        />
       </HvVerticalNavigationActions>
     </HvVerticalNavigation>
   );
 }
 
-const CollapsibleButton = ({
-  collapsed,
-  label,
-  icon,
-  ...others
-}: CollapsibleButtonProps) => {
+const CollapsibleButton = ({ collapsed, label, icon, ...others }) => {
   const props = collapsed
     ? { "aria-label": String(label), children: icon, icon: true }
     : { startIcon: icon, children: label };
@@ -427,10 +296,18 @@ const CollapsibleButton = ({
   return <HvButton {...props} {...others} />;
 };
 
-const data = [
-  { id: "00", label: "Jobs", icon: <Job /> },
-  { id: "01", label: "Charts", icon: <BarChart /> },
-  { id: "02", label: "Deployment", icon: <Deploy /> },
-  { id: "03", label: "Cloud", icon: <Cloud /> },
+const navigationData = [
+  { id: "explore", label: "Explore", icon: <Map /> },
+  {
+    id: "analytics",
+    label: "Business Analytics",
+    icon: <BarChart />,
+    data: [
+      { id: "analytics-models", label: "Semantic Models", icon: <DataStore /> },
+      { id: "analytics-reports", label: "Business Reports", icon: <Doc /> },
+    ],
+  },
+  { id: "management", label: "Management", icon: <Deploy /> },
+  { id: "settings", label: "Settings" },
 ];
 ```

--- a/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.test.tsx
+++ b/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.test.tsx
@@ -87,5 +87,24 @@ describe("AppShellProvider component", () => {
 
       expect(await screen.findByText("dummy")).toBeInTheDocument();
     });
+
+    it("should log error if import of a system provider bundle fails and still render correctly", async () => {
+      await renderTestProvider(<div>dummy</div>, {
+        systemProviders: [
+          {
+            bundle: "dummySystemProvider",
+          },
+        ],
+      });
+
+      await waitFor(() => {
+        expect(consoleMock).toHaveBeenCalledWith(
+          "Failed to load bundle dummySystemProvider:",
+          expect.any(Error),
+        );
+      });
+
+      expect(await screen.findByText("dummy")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.tsx
+++ b/packages/app-shell-ui/src/components/AppShellProvider/AppShellProvider.tsx
@@ -7,7 +7,6 @@ import {
   HvAppShellRuntimeContext,
   type HvAppShellConfig,
   type HvAppShellModel,
-  type HvAppShellProvidersComponent,
 } from "@pentaho/app-shell-shared";
 import { themes as baseThemes, HvProvider } from "@pentaho/uikit-react-core";
 import type { HvThemeColorMode, HvThemeStructure } from "@pentaho/uikit-styles";
@@ -57,21 +56,15 @@ const AppShellProviderInner = ({
       return;
     }
 
-    const providersComponents: HvAppShellProvidersComponent[] = [];
+    return filteredModel.providers.flatMap(({ bundle, key, config }) => {
+      const component = model.preloadedBundles.get(bundle) as
+        | React.ComponentType<React.PropsWithChildren>
+        | undefined;
 
-    for (const { bundle, key, config } of filteredModel.providers) {
-      const component = model.preloadedBundles.get(
-        bundle,
-      ) as React.ComponentType<React.PropsWithChildren>;
+      if (!component) return [];
 
-      providersComponents.push({
-        key,
-        component,
-        config,
-      });
-    }
-
-    return providersComponents;
+      return [{ key, component, config }];
+    });
   }, [filteredModel?.providers, model.preloadedBundles]);
 
   const providersContext = useMemo(
@@ -134,11 +127,15 @@ export function HvAppShellProvider({
   const systemProviders = useMemo(() => {
     if (!model?.systemProviders) return undefined;
 
-    return model.systemProviders.map(({ key, bundle, config }) => ({
-      key,
-      component: model.preloadedBundles.get(bundle) as React.ComponentType,
-      config,
-    }));
+    return model.systemProviders.flatMap(({ key, bundle, config }) => {
+      const component = model.preloadedBundles.get(bundle) as
+        | React.ComponentType
+        | undefined;
+
+      if (!component) return [];
+
+      return [{ key, component, config }];
+    });
   }, [model?.systemProviders, model?.preloadedBundles]);
 
   // Wait for config and condition bundles to load

--- a/packages/app-shell-ui/src/components/layout/VerticalNavigation/VerticalNavigation.tsx
+++ b/packages/app-shell-ui/src/components/layout/VerticalNavigation/VerticalNavigation.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { css, cx } from "@emotion/css";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
@@ -78,9 +78,17 @@ export const VerticalNavigation = () => {
     }
   };
 
-  useResizeObserver(ref, (width) => {
-    setVerticalNavigationWidth(isCompactMode ? 0 : width);
-  });
+  useResizeObserver(
+    ref,
+    useCallback(
+      (width) => {
+        // In compact mode the navigation floats/overlays, so it shouldn't
+        // reserve any space in the layout grid.
+        setVerticalNavigationWidth(isCompactMode ? 0 : width);
+      },
+      [isCompactMode, setVerticalNavigationWidth],
+    ),
+  );
 
   return (
     <ClickAwayListener

--- a/packages/app-shell-ui/src/hooks/useResizeObserver.ts
+++ b/packages/app-shell-ui/src/hooks/useResizeObserver.ts
@@ -8,7 +8,9 @@ export function useResizeObserver(
     if (!ref.current) return undefined;
 
     const observer = new ResizeObserver(([entry]) => {
-      onResize(entry.contentRect.width, entry.contentRect.height);
+      const { width, height } = entry.target.getBoundingClientRect();
+
+      onResize(Math.ceil(width), Math.ceil(height));
     });
 
     observer.observe(ref.current);

--- a/packages/app-shell-ui/src/tests/TestProvider.tsx
+++ b/packages/app-shell-ui/src/tests/TestProvider.tsx
@@ -8,6 +8,7 @@ import {
   CONFIG_TRANSLATIONS_NAMESPACE,
   HvAppShellI18nContext,
   HvAppShellRuntimeContext,
+  useHvAppShellCombinedProviders,
   type HvAppShellConfig,
 } from "@pentaho/app-shell-shared";
 import { HvProvider } from "@pentaho/uikit-react-core";
@@ -19,6 +20,7 @@ import en from "../locales/en/appShell.json";
 import GenericError from "../pages/GenericError";
 import { BannerProvider } from "../providers/BannerProvider";
 import { NavigationProvider } from "../providers/NavigationProvider";
+import CombinedProviders from "../utils/CombinedProviders";
 
 interface TestProviderProps extends PropsWithChildren {
   bundles?: Record<string, object>;
@@ -61,15 +63,21 @@ const createTestI18nInstance = (bundles?: Record<string, object>) => {
   return instance;
 };
 
-const DummyRoot = ({ children }: { children: ReactNode }) => (
-  <ErrorBoundary fallback={<GenericError />}>
-    <Suspense fallback={null}>
-      <NavigationProvider>
-        <BannerProvider>{children}</BannerProvider>
-      </NavigationProvider>
-    </Suspense>
-  </ErrorBoundary>
-);
+const DummyRoot = ({ children }: { children: ReactNode }) => {
+  const { providers } = useHvAppShellCombinedProviders();
+
+  return (
+    <ErrorBoundary fallback={<GenericError />}>
+      <CombinedProviders providers={providers}>
+        <Suspense fallback={null}>
+          <NavigationProvider>
+            <BannerProvider>{children}</BannerProvider>
+          </NavigationProvider>
+        </Suspense>
+      </CombinedProviders>
+    </ErrorBoundary>
+  );
+};
 
 const TestProvider = ({
   children,

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,6 +28,10 @@
     "./oxlint/*.json": "./oxlint/*.json",
     "./tsconfig": "./tsconfig.json"
   },
+  "peerDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
+    "prettier": "^3.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/core/src/VerticalNavigation/NavigationPopup/NavigationPopup.styles.tsx
+++ b/packages/core/src/VerticalNavigation/NavigationPopup/NavigationPopup.styles.tsx
@@ -4,10 +4,27 @@ import { theme } from "@pentaho/uikit-styles";
 export const { staticClasses, useClasses } = createClasses(
   "HvVerticalNavigationPopup",
   {
-    popup: {},
-    container: {
-      marginLeft: theme.spacing("xs"),
+    popup: { "--hv-popup-nav-bg": theme.colors.bgContainer },
+    wrapper: {
+      // position:relative is the containing block for the absolutely-positioned arrow
+      position: "relative",
+      // reserve space on the left for the arrow so it stays inside the Popper's
+      // clip box, keeping it visible even when a consumer sets `overflow` on the
+      // Popper root (e.g. to make a long menu scrollable)
+      paddingLeft: 8,
     },
+    arrow: {
+      position: "absolute",
+      // sits in the reserved padding strip, flush against the Popper's left edge
+      left: 0,
+      width: 0,
+      height: 0,
+      borderTop: `${theme.space.xs} solid transparent`,
+      borderBottom: `${theme.space.xs} solid transparent`,
+      // top is set dynamically (inline) by Popper.js arrow modifier
+      borderRight: `${theme.space.xs} solid var(--hv-popup-nav-bg)`,
+    },
+    container: {},
     popper: {
       zIndex: theme.zIndices.popover,
     },

--- a/packages/core/src/VerticalNavigation/NavigationPopup/NavigationPopupContainer.tsx
+++ b/packages/core/src/VerticalNavigation/NavigationPopup/NavigationPopupContainer.tsx
@@ -1,6 +1,11 @@
+import { useMemo, useState } from "react";
 import ClickAwayListener from "@mui/material/ClickAwayListener";
 import Popper from "@mui/material/Popper";
-import { useTheme, type ExtractNames } from "@pentaho/uikit-react-utils";
+import {
+  useDefaultProps,
+  useTheme,
+  type ExtractNames,
+} from "@pentaho/uikit-react-utils";
 
 import type { HvBaseProps } from "../../types/generic";
 import { getContainerElement } from "../../utils/document";
@@ -17,17 +22,36 @@ export interface NavigationPopupContainerProps extends HvBaseProps {
   classes?: HvVerticalNavigationPopupClasses;
 }
 
-export const NavigationPopupContainer = ({
-  anchorEl,
-  onClose,
-  children,
-  classes: classesProp,
-  className,
-  ...others
-}: NavigationPopupContainerProps) => {
+export const NavigationPopupContainer = (
+  props: NavigationPopupContainerProps,
+) => {
+  const {
+    anchorEl,
+    onClose,
+    children,
+    classes: classesProp,
+    className,
+    ...others
+  } = useDefaultProps("HvVerticalNavigationPopup", props);
+
   const { classes, cx } = useClasses(classesProp);
 
   const { rootId } = useTheme();
+
+  const [arrowRef, setArrowRef] = useState<HTMLElement | null>(null);
+
+  const modifiers = useMemo(
+    () => [
+      // arrow lives inside the wrapper's reserved left padding, so no offset
+      // gap is needed — the Popper sits flush against the anchor
+      {
+        name: "arrow",
+        enabled: Boolean(arrowRef),
+        options: { element: arrowRef },
+      },
+    ],
+    [arrowRef],
+  );
 
   const handleClickAway = () => onClose?.();
 
@@ -37,14 +61,18 @@ export const NavigationPopupContainer = ({
       anchorEl={anchorEl}
       placement="right-start"
       container={getContainerElement(rootId)}
+      modifiers={modifiers}
       className={cx(classes.popper, classes.popup, className)}
       {...others}
     >
       <ClickAwayListener onClickAway={handleClickAway}>
-        <div className={classes.container}>
-          <HvVerticalNavigation open useIcons>
-            {children}
-          </HvVerticalNavigation>
+        <div className={classes.wrapper}>
+          <div ref={setArrowRef} className={classes.arrow} />
+          <div className={classes.container}>
+            <HvVerticalNavigation open useIcons>
+              {children}
+            </HvVerticalNavigation>
+          </div>
         </div>
       </ClickAwayListener>
     </Popper>

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -2,7 +2,7 @@ import { createClasses } from "@pentaho/uikit-react-utils";
 import { blue, neutral, slate, theme } from "@pentaho/uikit-styles";
 
 import { avatarClasses } from "../../Avatar";
-import { outlineStyles } from "../../utils/focusUtils";
+import { insetOutlineStyles } from "../../utils/focusUtils";
 
 const selected = {
   background: theme.colors.bgPageSecondary,
@@ -58,6 +58,11 @@ export const { staticClasses, useClasses } = createClasses(
         "& $icon": {
           marginRight: 0,
           width: 32,
+          justifyContent: "center",
+          "> div:first-of-type": {
+            padding: 0,
+            marginLeft: 0,
+          },
         },
       },
       "$expandable>&": {
@@ -73,11 +78,11 @@ export const { staticClasses, useClasses } = createClasses(
       ":not($disabled>&):not($selected>&).focus-visible": { ...hover },
 
       "*:focus-visible $focused>&": {
-        ...outlineStyles,
+        ...insetOutlineStyles,
       },
 
       ".focus-visible $focused>&": {
-        ...outlineStyles,
+        ...insetOutlineStyles,
       },
       "$focused>&": {
         ...hover,
@@ -106,11 +111,11 @@ export const { staticClasses, useClasses } = createClasses(
       },
 
       "&:focus-visible": {
-        ...outlineStyles,
+        ...insetOutlineStyles,
       },
 
       "&.focus-visible": {
-        ...outlineStyles,
+        ...insetOutlineStyles,
       },
 
       // cursor

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.styles.tsx
@@ -20,16 +20,20 @@ export const { staticClasses, useClasses } = createClasses(
       listStyle: "none",
       minHeight: "32px",
       "&:not(:last-child)": {
-        marginBottom: "8px",
+        marginBottom: theme.space.xs,
       },
       "&$collapsed": {
-        "&>$group": {
-          display: "none",
+        "&>$groupWrapper": {
+          gridTemplateRows: "0fr",
+          paddingTop: 0,
+          visibility: "hidden",
+          transition:
+            "grid-template-rows 250ms ease, padding-top 250ms ease, visibility 0s 250ms",
         },
       },
       "&$expanded": {
-        "&>$group": {
-          display: "block",
+        "&>$groupWrapper": {
+          gridTemplateRows: "1fr",
         },
       },
       "&$link": {
@@ -51,6 +55,10 @@ export const { staticClasses, useClasses } = createClasses(
       "&$minimized": {
         justifyContent: "center",
         paddingRight: 0,
+        "& $icon": {
+          marginRight: 0,
+          width: 32,
+        },
       },
       "$expandable>&": {
         fontWeight: 600,
@@ -119,9 +127,23 @@ export const { staticClasses, useClasses } = createClasses(
       },
     },
     link: {},
+    groupWrapper: {
+      display: "grid",
+      gridTemplateRows: "1fr",
+      overflow: "hidden",
+      paddingTop: theme.space.xs,
+      transition:
+        "grid-template-rows 250ms ease, padding-top 250ms ease, visibility 0s",
+      visibility: "visible",
+    },
     group: {
-      margin: "8px 0 0 0",
       padding: 0,
+      minHeight: 0,
+      overflow: "hidden",
+      "--hv-content-padding": "0px",
+      borderLeft: `1px solid ${theme.alpha("border", 0.3)}`,
+      marginLeft: "calc(var(--hv-nav-item-padding, 0px) + 16px)",
+      paddingLeft: theme.space.sm,
     },
     disabled: {
       "& .HvVerticalNavigationTreeViewItem-label": {
@@ -147,19 +169,13 @@ export const { staticClasses, useClasses } = createClasses(
       display: "flex",
       flexGrow: 1,
       maxWidth: "100%",
+      gap: theme.space.xs,
     },
-    labelIcon: {
-      maxWidth: "calc(100% - 32px)",
-    },
-    labelExpandable: {
-      maxWidth: "calc(100% - 32px)",
-
-      "&$labelIcon": {
-        maxWidth: "calc(100% - 64px)",
-      },
-    },
+    labelIcon: {},
+    labelExpandable: {},
     icon: {
       display: "flex",
+      marginRight: theme.space.xs,
       alignItems: "center",
       "> div:first-of-type": {
         marginLeft: "var(--icon-margin-left)",

--- a/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
+++ b/packages/core/src/VerticalNavigation/TreeView/TreeViewItem.tsx
@@ -16,6 +16,7 @@ import {
 
 import { HvAvatar } from "../../Avatar";
 import { useForkRef } from "../../hooks/useForkRef";
+import { HvIconContainer } from "../../IconContainer";
 import { HvIcon } from "../../icons";
 import { HvOverflowTooltip } from "../../OverflowTooltip";
 import { HvTooltip } from "../../Tooltip";
@@ -435,6 +436,9 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
       [expandable, handleExpansion, handleSelection, selectable, isOpen],
     );
 
+    const levelPadding =
+      (useIcons || !isOpen ? 0 : 10) + level * (collapsible ? 16 : 10);
+
     const renderedContent = useMemo(() => {
       const buttonLinkProps = {
         href,
@@ -463,9 +467,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
             onClick={handleClick}
             onMouseDown={handleMouseDown}
             style={{
-              paddingLeft:
-                (useIcons || !isOpen ? 0 : 10) +
-                level * (collapsible ? 16 : 10),
+              paddingLeft: `var(--hv-content-padding, ${levelPadding}px)`,
             }}
             role={isLink ? undefined : "button"}
             {...(treeviewMode
@@ -503,12 +505,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
                   {payload?.label?.slice(0, 1)}
                 </HvAvatar>
               ) : (
-                useIcons && icon
-              )}
-              {hasChildren && !isOpen ? (
-                <HvIcon name="Forwards" size="xs" compact />
-              ) : (
-                hasAnyChildWithData && !isOpen && <div />
+                useIcons && <HvIconContainer>{icon}</HvIconContainer>
               )}
             </div>
 
@@ -524,7 +521,12 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
             )}
 
             {isOpen && expandable && (
-              <HvIcon name="CaretDown" size="xs" rotate={expanded} />
+              <HvIcon
+                name="CaretDown"
+                size="xs"
+                rotate={expanded}
+                style={{ marginLeft: "auto" }}
+              />
             )}
           </HvTypography>
         </HvTooltip>
@@ -549,8 +551,7 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
       handleClick,
       handleMouseDown,
       useIcons,
-      level,
-      collapsible,
+      levelPadding,
       treeviewMode,
       handleFocus,
       selectable,
@@ -568,15 +569,17 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
     const renderedChildren = useMemo(
       () =>
         children && (
-          <ul
-            id={groupId}
-            className={classes.group}
-            role={treeviewMode ? "group" : undefined}
-          >
-            {children}
-          </ul>
+          <div className={classes.groupWrapper}>
+            <ul
+              id={groupId}
+              className={classes.group}
+              role={treeviewMode ? "group" : undefined}
+            >
+              {children}
+            </ul>
+          </div>
         ),
-      [children, classes?.group, groupId, treeviewMode],
+      [children, classes?.group, classes?.groupWrapper, groupId, treeviewMode],
     );
 
     return (
@@ -612,6 +615,11 @@ export const HvVerticalNavigationTreeViewItem = forwardRef(
           "aria-disabled": disabled ? true : undefined,
         })}
         {...others}
+        style={
+          {
+            "--hv-nav-item-padding": `var(--hv-content-padding, ${levelPadding}px)`,
+          } as React.CSSProperties
+        }
       >
         {renderedContent}
         {isOpen && (

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.stories.tsx
@@ -54,6 +54,23 @@ export const Test: StoryObj<HvVerticalNavigationProps> = {
   play: async ({ canvas, userEvent }) => {
     const buttons = canvas.getAllByRole("button", { name: "collapseButton" });
     await userEvent.click(buttons[0]);
+
+    // expanding animates the width, which shifts the navigation the popup
+    // anchors to. the popup measures its anchor once, so wait for the
+    // transition before opening it — with a fallback for reduced motion
+    const nav = buttons[0].closest<HTMLElement>(".HvVerticalNavigation-root");
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 400);
+      nav?.addEventListener(
+        "transitionend",
+        () => {
+          clearTimeout(timeout);
+          resolve();
+        },
+        { once: true },
+      );
+    });
+
     const hwButtons = canvas.getAllByRole("button", { name: /hardware/i });
     expect(hwButtons).toHaveLength(2);
     await userEvent.click(hwButtons[1]);

--- a/packages/core/src/VerticalNavigation/VerticalNavigation.styles.tsx
+++ b/packages/core/src/VerticalNavigation/VerticalNavigation.styles.tsx
@@ -10,34 +10,59 @@ export const { staticClasses, useClasses } = createClasses(
       justifyContent: "flex-start",
 
       width: "280px",
+      overflow: "hidden",
+      transition: "width 300ms ease",
+      "@media (prefers-reduced-motion: reduce)": {
+        transition: "none",
+      },
 
+      colorScheme: "light",
+      padding: theme.space.sm,
+      paddingTop: 32,
       color: theme.colors.textLight,
-      backgroundColor: slate[900],
+      backgroundColor: `var(--hv-popup-nav-bg, ${slate[900]})`,
       boxShadow: `inset -1px 0 0 0 ${slate[500]}`,
       clipPath: "inset(0px -12px 0px 0px)",
 
+      "& > * + *": {
+        padding: 0,
+        paddingTop: theme.space.sm,
+        borderTop: `1px solid ${theme.alpha("border", 0.3)}`,
+      },
+      "& > * + div": {
+        borderTop: `1px solid ${slate[500]}`,
+      },
       "& > :only-child": {
         padding: theme.space.sm,
         "& .HvVerticalNavigationSlider-listContainer": { padding: 0 },
       },
-      "& > :not(nav:first-of-type)": {
-        borderTop: `1px solid ${slate[500]}`,
-        padding: theme.spacing("xs", "sm", "sm", "sm"),
+      "& > :first-child": {
+        padding: 0,
+        paddingBottom: theme.space.sm,
       },
 
-      "& > :first-of-type:not(:last-child)": {
-        borderTop: "none",
-        padding: theme.spacing("sm", "sm", "xs", "sm"),
+      ".HvVerticalNavigationPopup-wrapper:has(&)": {
+        "--hv-popup-nav-bg": slate[800],
+      },
+      ".HvVerticalNavigationPopup-container:has(> &)": {
+        borderRadius: theme.radii.round,
+        overflow: "hidden",
+      },
+      ".HvVerticalNavigationPopup-container &": {
+        padding: theme.space.sm,
+        paddingBottom: 0,
       },
     },
     collapsed: {
-      width: "fit-content",
-      "& > :first-of-type:not(:last-child)": {
-        padding: theme.spacing("sm", "xs", "xs", "xs"),
+      // calc: (padding-left + padding-right) + icon width
+      width: `calc(${theme.space.sm} * 2 + 32px)`,
+      "& > :first-child": {
+        padding: 0,
+        paddingBottom: theme.space.sm,
       },
-
-      "& > :not(nav:first-of-type)": {
-        padding: theme.spacing("xs", "xs", "sm", "xs"),
+      "& > * + *": {
+        padding: 0,
+        paddingTop: theme.space.sm,
       },
     },
 

--- a/packages/core/src/utils/focusUtils.ts
+++ b/packages/core/src/utils/focusUtils.ts
@@ -2,3 +2,9 @@ export const outlineStyles = {
   outline: "none", // remove the default outlines
   boxShadow: "0 0 0 1px #52A8EC, 0 0 0 4px rgba(29,155,209,.3)",
 };
+
+/** `outlineStyles` drawn inside the element, for containers that clip their overflow. */
+export const insetOutlineStyles = {
+  ...outlineStyles,
+  boxShadow: "inset 0 0 0 1px #52A8EC, inset 0 0 0 4px rgba(29,155,209,.3)",
+};


### PR DESCRIPTION
Ports the portable master commits to `next`, original authors preserved:

- `chore: ignore generated changelogs in prettier` (#5259)
- `fix(config): restore prettier plugin dependency` (#5260)
- `feat(AppShell): improve provider handling and error logging` (#5242)
- `feat(VerticalNavigation): update styles to PD 0.12` (#5209)
- `test(VerticalNavigation): fix flaky popup snapshot` (#5263)
- `fix(VerticalNavigation): clipped focus ring and off-center icons when collapsed` (#5266)

**Not ported:** `chore(release): publish` ×2 (v6 versions), #5232 + its revert (net-zero), two dependabot bumps.

**#5209 was adapted, not copied.** #5236 promoted the Pentaho overrides into the components, so its theme changes went into `VerticalNavigation.styles.tsx` and `TreeViewItem.styles.tsx`; `pentaho.ts` is untouched. The `data-theme` / `data-color-mode` default props still need a home on the component.

Supersedes #5264.
