### PR TITLE
docs: correct the v7 migration guide and flag the icon library as internal

### DIFF
--- a/apps/docs/src/content/components/index.mdx
+++ b/apps/docs/src/content/components/index.mdx
@@ -43,4 +43,3 @@ Besides the `core` package, we also provide the following component packages tha
 - [`@pentaho/uikit-react-widgets`](https://npm.im/@pentaho/uikit-react-widgets) ([Docs](/components/pentaho)): React components for tailored for Pentaho products.
 - [`@pentaho/uikit-react-viz`](https://npm.im/@pentaho/uikit-react-viz) ([Docs](/components/charts)): A collection of chart components for use in your application.
 - [`@pentaho/uikit-react-code-editor`](https://npm.im/@pentaho/uikit-react-code-editor) ([Docs](/components/code-editor)): A specialized wrapper around the [Monaco Editor](https://microsoft.github.io/monaco-editor).
-- [`@pentaho/uikit-react-icons`](https://npm.im/@pentaho/uikit-react-icons) ([Docs](/docs/icon-library)): A collection of React icons for the NEXT Design System.

--- a/apps/docs/src/content/docs/icon-library.mdx
+++ b/apps/docs/src/content/docs/icon-library.mdx
@@ -2,13 +2,20 @@ import { IconLibrary, IconPlayground } from "../../components/icons";
 
 # Icon Library
 
-The **UI Kit** includes a comprehensive library of SVG icons packaged as React components, specifically designed for use with the [NEXT Design System](https://designsystem.hitachi.com).
+> [!WARNING]
+>
+> `@pentaho/uikit-react-icons` is **internal to UI Kit** from v7 onwards. It is not
+> published to npm, and it is slated for deprecation.
+>
+> To use icons in your own application, see [Icons](/docs/icons) — UI Kit works with
+> any icon set that follows the `currentColor` and `1em` conventions.
 
-These icons are available through the `@pentaho/uikit-react-icons` package and are fully compatible with the [`HvIconContainer`](/components/icon-container) API, ensuring consistent sizing, color, and alignment across the system.
+This page lists the icons bundled with UI Kit. It is kept as a reference for the icon
+names used in [App Shell configuration](/app-shell/configuration#menu), where a menu or
+header action declares `iconType: "uikit"` and identifies an icon by `name`.
 
-```tsx
-import { Alert } from "@pentaho/uikit-react-icons";
-```
+These icons are compatible with the [`HvIconContainer`](/components/icon-container) API,
+so sizing, color, and alignment stay consistent wherever UI Kit renders them.
 
 <br />
 

--- a/apps/docs/src/content/docs/migration.md
+++ b/apps/docs/src/content/docs/migration.md
@@ -52,7 +52,7 @@ Every package that existed in `v6.10.0`, with its v7 name and status.
 | `@hitachivantara/app-shell-vite-plugin`   | `@pentaho/app-shell-vite-plugin`   | Renamed, public      |
 | `@hitachivantara/internal`                | `@pentaho/internal`                | Renamed, private     |
 | `@hitachivantara/uikit-cli`               | `@pentaho/uikit-cli`               | Renamed, public      |
-| `@hitachivantara/uikit-config`            | `@pentaho/uikit-config`            | Renamed, now private |
+| `@hitachivantara/uikit-config`            | `@pentaho/uikit-config`            | Renamed, public      |
 | `@hitachivantara/uikit-react-code-editor` | `@pentaho/uikit-react-code-editor` | Renamed, public      |
 | `@hitachivantara/uikit-react-core`        | `@pentaho/uikit-react-core`        | Renamed, public      |
 | `@hitachivantara/uikit-react-icons`       | `@pentaho/uikit-react-icons`       | Renamed, now private |
@@ -139,7 +139,23 @@ The default body font changed from Open Sans to Inter.
 
 If your application relied on Open Sans being bundled, you can load it yourself.
 
-### 8) Core components removed
+### 8) UnoCSS preset renamed
+
+`@pentaho/uikit-uno-preset` exports `presetUikit` instead of `presetHv`.
+
+```diff
+-import { presetHv } from "@hitachivantara/uikit-uno-preset";
++import { presetUikit } from "@pentaho/uikit-uno-preset";
+
+ export default defineConfig({
+-  presets: [presetHv()],
++  presets: [presetUikit()],
+ });
+```
+
+Missing this shows up when the dev server starts, as `presetHv is not a function`.
+
+### 9) Core components removed
 
 The following components are no longer part of `@pentaho/uikit-react-core`. They weren't deprecated in v6, so it's worth searching for them directly — a clean v6 build won't flag them:
 
@@ -160,7 +176,7 @@ Recommended alternatives:
 - `HvSimpleGrid`: replace with utility-grid layouts such as `grid grid-cols-2 md:grid-cols-4`.
 - `HvStack`: replace with flex layouts such as `flex gap-sm` (row/column as needed).
 
-### 9) Props and style classes removed
+### 10) Props and style classes removed
 
 Most of these were deprecated during v6. `disableClear`, `disableRevealPassword`, `disableSearchButton`, and `semantic` weren't, so it's worth searching for those directly.
 
@@ -182,7 +198,7 @@ Most of these were deprecated during v6. `disableClear`, `disableRevealPassword`
 +<HvInput hideClear hideSearchButton />
 ```
 
-### 10) Internal base primitives migrated
+### 11) Internal base primitives migrated
 
 Core and widgets internals migrated from `@mui/base` to `@base-ui/react`.
 
@@ -193,7 +209,7 @@ For most consumers this is transparent, but it can affect:
 
 It's worth revalidating any deep customization around `Select`, tabs/canvas panels, and dropdown-like controls.
 
-### 11) Grid implementation update
+### 12) Grid implementation update
 
 `HvGrid` now wraps `@mui/material/Grid` instead of `@mui/material/GridLegacy`. The `item` prop and the per-breakpoint props `xs`, `sm`, `md`, `lg`, `xl` were removed — sizing goes through `size`.
 
@@ -206,7 +222,7 @@ It's worth revalidating any deep customization around `Select`, tabs/canvas pane
 
 `spacing`, `rowSpacing`, `columnSpacing`, and `columns` are unchanged, but the underlying layout implementation differs — worth a visual check on nested or complex grids.
 
-### 12) CLI templates removed
+### 13) CLI templates removed
 
 Template scaffolding has been retired from `@pentaho/uikit-cli`. The `create` command now uses a single baseline and no longer takes `--templates`.
 

--- a/apps/docs/src/content/docs/migration.md
+++ b/apps/docs/src/content/docs/migration.md
@@ -153,7 +153,7 @@ If your application relied on Open Sans being bundled, you can load it yourself.
  });
 ```
 
-Missing this shows up when the dev server starts, as `presetHv is not a function`.
+Missing this shows up when the dev server starts, because `presetHv` is no longer exported (it will be undefined / a missing export error).
 
 ### 9) Core components removed
 


### PR DESCRIPTION
Aligns the docs with the final v7 package state.

- Adds the `presetHv` → `presetUikit` rename, the only export renamed in v7 and
  absent from the guide. It breaks any app with a `uno.config.ts` at dev-server
  startup, with an error that gives no hint a rename occurred.
- Corrects `uikit-config` from "now private" to public — the `private: true` in
  #5238 is a prerelease hold, not a removal.
- Keeps the icon library page but marks it internal-only, and drops it from the
  list of installable packages. It stays because it is the reference for the icon
  names used in App Shell `iconType: "uikit"` config.

Docs examples still import `@pentaho/uikit-react-icons`; migrating those is
deferred until they are aligned with PD.
