### PR TITLE
ci: add graduate and from-package release modes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "0 5 1,15 * *" # at 05:00 on day 1 and 15 of every month
   workflow_dispatch:
+    inputs:
+      mode:
+        description: |
+          default      version from conventional commits, then publish
+          graduate     take packages off the prerelease line (7.0.0-next.3 -> 7.0.0)
+          from-package publish the versions already committed, without bumping
+        type: choice
+        options: [default, graduate, from-package]
+        default: default
 
 concurrency:
   group: release
@@ -62,7 +71,18 @@ jobs:
 
       - name: Publish to NPM
         id: publish-npm
-        run: npm run publish
+        run: |
+          case "${{ inputs.mode || 'default' }}" in
+            graduate)
+              npx lerna publish --conventional-commits --conventional-graduate --yes
+              ;;
+            from-package)
+              npx lerna publish from-package --yes
+              ;;
+            *)
+              npm run publish
+              ;;
+          esac
         env:
           HUSKY: 0
 
@@ -72,16 +92,26 @@ jobs:
         # We only tag+publish+notify if there a new core package version
         run: |
           VERSION=v$(npm pkg get version --ws | sed -n 's/.*uikit-react-core": "\(.*\)".*/\1/p')
-          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+          if [ "$CURRENT_VERSION" = "$VERSION" ] && [ "${{ inputs.mode || 'default' }}" != "from-package" ]; then
             echo "No new uikit-react-core version to release. Exiting"
             exit 1
           fi
           echo "NEW_VERSION=$VERSION" >> "$GITHUB_ENV"
 
+      - name: Verify the publish
+        run: |
+          PKG=$(npm pkg get name -w packages/core | sed -n 's/.*"\(@[^"]*\)".*/\1/p' | head -1)
+          npm view "$PKG@${NEW_VERSION#v}" version
+          echo "Published $PKG@${NEW_VERSION#v}"
+
       - name: Tag Release
         run: |
-          git tag -a $NEW_VERSION -m "Version $NEW_VERSION"
-          git push origin $NEW_VERSION
+          if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+            echo "Tag $NEW_VERSION already exists, skipping"
+          else
+            git tag -a $NEW_VERSION -m "Version $NEW_VERSION"
+            git push origin $NEW_VERSION
+          fi
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish to NPM
         id: publish-npm
         run: |
-          case "${{ inputs.mode || 'default' }}" in
+          case "${{ github.event.inputs.mode || 'default' }}" in
             graduate)
               npx lerna publish --conventional-commits --conventional-graduate --yes
               ;;
@@ -92,7 +92,7 @@ jobs:
         # We only tag+publish+notify if there a new core package version
         run: |
           VERSION=v$(npm pkg get version --ws | sed -n 's/.*uikit-react-core": "\(.*\)".*/\1/p')
-          if [ "$CURRENT_VERSION" = "$VERSION" ] && [ "${{ inputs.mode || 'default' }}" != "from-package" ]; then
+          if [ "$CURRENT_VERSION" = "$VERSION" ] && [ "${{ github.event.inputs.mode || 'default' }}" != "from-package" ]; then
             echo "No new uikit-react-core version to release. Exiting"
             exit 1
           fi
@@ -106,11 +106,11 @@ jobs:
 
       - name: Tag Release
         run: |
-          if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/$NEW_VERSION"; then
             echo "Tag $NEW_VERSION already exists, skipping"
           else
-            git tag -a $NEW_VERSION -m "Version $NEW_VERSION"
-            git push origin $NEW_VERSION
+            git tag -a "$NEW_VERSION" -m "Version $NEW_VERSION"
+            git push origin "$NEW_VERSION"
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
Adds release modes to `release.yml` so prerelease graduation can happen in CI, and
asserts that the npm upload actually succeeded.

## Why

The workflow only knew `npm run publish` (`lerna publish`) — version from conventional
commits, then upload. It can't graduate `7.0.0-next.3` → `7.0.0`, and it can't publish
versions already committed. Graduating v7 therefore had to happen outside CI, skipping
the workflow-only steps: the aggregate tag, the GitHub release, and the npm publish.

## Changes

New `mode` input on `workflow_dispatch`:

- `default` — unchanged
- `graduate` — off the prerelease line, `7.0.0-next.3` → `7.0.0`
- `from-package` — publish committed versions, no bump

Scheduled runs are unaffected (`inputs.mode || 'default'`).

`Set NEW_VERSION` no longer exits 1 in `from-package` mode, where the version
deliberately doesn't change.

New `Verify the publish` step before tagging:

```yaml
npm view "$PKG@${NEW_VERSION#v}" version
