### PR TITLE
ci: drop the publish verification and tidy the dispatch input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: |
-          default      version from conventional commits, then publish
-          graduate     take packages off the prerelease line (7.0.0-next.3 -> 7.0.0)
-          from-package publish the versions already committed, without bumping
+        description: "How to release. See the workflow file for details."
         type: choice
-        options: [default, graduate, from-package]
+        options:
+          - default # version from conventional commits, then publish
+          - graduate # leave the prerelease line, e.g. 7.0.0-next.3 -> 7.0.0
+          - from-package # publish committed versions, without bumping
         default: default
 
 concurrency:
@@ -97,12 +97,6 @@ jobs:
             exit 1
           fi
           echo "NEW_VERSION=$VERSION" >> "$GITHUB_ENV"
-
-      - name: Verify the publish
-        run: |
-          PKG=$(npm pkg get name -w packages/core | sed -n 's/.*"\(@[^"]*\)".*/\1/p' | head -1)
-          npm view "$PKG@${NEW_VERSION#v}" version
-          echo "Published $PKG@${NEW_VERSION#v}"
 
       - name: Tag Release
         run: |


### PR DESCRIPTION
Removes the publish verification step from #5270, and shortens the dispatch description.

The multi-line `description` rendered as one run-on blob in the dropdown, since GitHub
flattens it. Now a single line, with per-mode notes as comments beside each option.

Release modes and the tag-specific existence check are unaffected.
